### PR TITLE
Implement async portfolio analysis

### DIFF
--- a/analyzers/__init__.py
+++ b/analyzers/__init__.py
@@ -1,4 +1,5 @@
 from .portfolio_analyzer import PortfolioAnalyzer
 from .rebalancing_analyzer import RebalancingAnalyzer
+from .async_portfolio_analyzer import AsyncPortfolioAnalyzer
 
-__all__ = ['PortfolioAnalyzer', 'RebalancingAnalyzer']
+__all__ = ['PortfolioAnalyzer', 'AsyncPortfolioAnalyzer', 'RebalancingAnalyzer']

--- a/analyzers/async_portfolio_analyzer.py
+++ b/analyzers/async_portfolio_analyzer.py
@@ -1,0 +1,81 @@
+import asyncio
+import logging
+from typing import Dict, Tuple
+
+from langgraph.graph import StateGraph, START, END
+from langsmith import traceable
+
+from models.state import State, PortfolioPosition, Portfolio, AnalysisResult
+from .portfolio_analyzer import PortfolioAnalyzer
+
+logger = logging.getLogger(__name__)
+
+class AsyncPortfolioAnalyzer(PortfolioAnalyzer):
+    """Асинхронная версия PortfolioAnalyzer с параллельной обработкой тикеров."""
+
+    def __init__(self, max_concurrent_tasks: int = 5):
+        super().__init__()
+        self.semaphore = asyncio.Semaphore(max_concurrent_tasks)
+
+    async def _analyze_single(self, chain, position: PortfolioPosition) -> Tuple[str, AnalysisResult]:
+        """Анализирует один тикер асинхронно."""
+        async with self.semaphore:
+            initial_state = {
+                "ticker": position.ticker,
+                "quantity": position.quantity,
+                "news": "",
+                "semantic": "",
+                "moex_data": "",
+                "moex_data_analysis": "",
+                "ifrs_data": "",
+                "market_news": "",
+                "final_data": "",
+            }
+            logger.info(f"Async processing {position.ticker} with quantity {position.quantity}")
+            result = await asyncio.to_thread(chain.invoke, initial_state)
+
+            recommendation = "ДЕРЖАТЬ"
+            if "КУПИТЬ" in result["final_data"]:
+                recommendation = "КУПИТЬ"
+            elif "ПРОДАВАТЬ" in result["final_data"]:
+                recommendation = "ПРОДАВАТЬ"
+
+            analysis_result = AnalysisResult(
+                ticker=position.ticker,
+                recommendation=recommendation,
+                confidence=0.8,
+                analysis_data={
+                    "market_news": result.get("market_news", ""),
+                    "semantic": result.get("semantic", ""),
+                    "moex_analysis": result.get("moex_data_analysis", ""),
+                    "ifrs_data": result.get("ifrs_data", ""),
+                    "final_decision": result.get("final_data", ""),
+                },
+            )
+            return position.ticker, analysis_result
+
+    async def analyze_portfolio_async(self, portfolio: Portfolio) -> Dict[str, AnalysisResult]:
+        """Анализирует портфель асинхронно."""
+        workflow = StateGraph(State)
+        workflow.add_node("generate_market_news", self.generate_market_news)
+        workflow.add_node("generate_news", self.generate_news)
+        workflow.add_node("grade_news", self.grade_news)
+        workflow.add_node("moex_news", self.moex_news)
+        workflow.add_node("make_trade_analysis", self.make_trade_analysis)
+        workflow.add_node("ifrs_analysis", self.ifrs_analysis)
+        workflow.add_node("final_analysis", self.final_analysis)
+
+        workflow.add_edge(START, "generate_market_news")
+        workflow.add_edge("generate_market_news", "generate_news")
+        workflow.add_edge("generate_news", "grade_news")
+        workflow.add_edge("grade_news", "moex_news")
+        workflow.add_edge("moex_news", "make_trade_analysis")
+        workflow.add_edge("make_trade_analysis", "ifrs_analysis")
+        workflow.add_edge("ifrs_analysis", "final_analysis")
+        workflow.add_edge("final_analysis", END)
+
+        chain = workflow.compile()
+
+        tasks = [self._analyze_single(chain, position) for position in portfolio.positions]
+        results = await asyncio.gather(*tasks)
+        return {ticker: res for ticker, res in results}

--- a/models/state.py
+++ b/models/state.py
@@ -32,14 +32,22 @@ class PortfolioPosition(BaseModel):
 
 class Portfolio(BaseModel):
     positions: List[PortfolioPosition]
-    
+
     @classmethod
     def from_dict(cls, data: Dict[str, int]):
         positions = [PortfolioPosition(ticker=k, quantity=v) for k, v in data.items()]
         return cls(positions=positions)
 
-@dataclass
-class AnalysisResult:
+    def get_tickers(self) -> List[str]:
+        return [pos.ticker for pos in self.positions]
+
+    def get_position(self, ticker: str) -> Optional[PortfolioPosition]:
+        for pos in self.positions:
+            if pos.ticker == ticker:
+                return pos
+        return None
+
+class AnalysisResult(BaseModel):
     """
     Результат анализа тикера.
     
@@ -53,3 +61,9 @@ class AnalysisResult:
     recommendation: str
     confidence: float
     analysis_data: Dict[str, str]
+
+    @validator('confidence')
+    def validate_confidence(cls, v):
+        if not 0.0 <= v <= 1.0:
+            raise ValueError('Confidence must be between 0 and 1')
+        return v

--- a/tests/test_async_analyzer.py
+++ b/tests/test_async_analyzer.py
@@ -1,0 +1,30 @@
+import asyncio
+import pytest
+from analyzers import AsyncPortfolioAnalyzer
+from models import Portfolio, PortfolioPosition, AnalysisResult
+
+
+@pytest.mark.asyncio
+async def test_analyze_portfolio_async(monkeypatch):
+    analyzer = AsyncPortfolioAnalyzer(max_concurrent_tasks=2)
+
+    async def fake_analyze_single(chain, position):
+        await asyncio.sleep(0.01)
+        return position.ticker, AnalysisResult(
+            ticker=position.ticker,
+            recommendation="КУПИТЬ",
+            confidence=1.0,
+            analysis_data={},
+        )
+
+    monkeypatch.setattr(analyzer, "_analyze_single", fake_analyze_single)
+
+    portfolio = Portfolio(positions=[
+        PortfolioPosition(ticker="AAA", quantity=1),
+        PortfolioPosition(ticker="BBB", quantity=2),
+    ])
+
+    result = await analyzer.analyze_portfolio_async(portfolio)
+
+    assert set(result.keys()) == {"AAA", "BBB"}
+    assert all(r.recommendation == "КУПИТЬ" for r in result.values())

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -38,7 +38,7 @@ def retry_on_failure(max_retries: int = 3, delay: float = 1.0):
 def has_only_ticker(text: str, ticker: str) -> bool:
     """Проверяет, содержит ли текст только указанный тикер"""
     tickers = re.findall(r'\b[A-Z]{3,4}\b', text)
-    return all(t == ticker for t in tickers) and tickers
+    return bool(tickers) and all(t == ticker for t in tickers)
 
 def truncate_text(text: str, max_length: int) -> str:
     """Обрезает текст до указанной длины"""


### PR DESCRIPTION
## Summary
- add AsyncPortfolioAnalyzer for parallel analysis
- expose async analyzer in package
- provide async entrypoint and call from `main.py`
- update helpers and data models to satisfy tests
- add async tests and adjust AI service

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686519fb1264832f8603e974209fe7d1