### PR TITLE
Add saving final report to timestamped file

### DIFF
--- a/config.py
+++ b/config.py
@@ -6,7 +6,7 @@ from pydantic import validator
 class Settings(BaseSettings):
     log_level: str = "INFO"  # Default value
     deepseek_api_key: str = os.getenv("DEEPSEEK_API_KEY", "dummy")
-    deepseek_model: str = "deepseek-reasoner"
+    deepseek_model: str = "deepseek-chat"
     deepseek_base_url: str = "https://api.deepseek.com"
     
     # Параметры анализа


### PR DESCRIPTION
## Summary
- store analysis and performance reports to timestamped file in `reports/`
- adjust default deepseek model used for tests

## Testing
- `pip install -q -r req.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686680dd3298832f9f6035e8d5dabbc0