### PR TITLE
Add RUB cash support and numeric rebalancing

### DIFF
--- a/main.py
+++ b/main.py
@@ -49,10 +49,10 @@ def analyze_portfolio_improved(portfolio_dict: dict) -> dict:
         analysis_results = portfolio_analyzer.analyze_portfolio(portfolio)
         
         # Получаем рекомендации по ребалансировке
-        rebalancing_suggestions = rebalancing_analyzer.suggest_rebalancing(analysis_results)
+        rebalancing_suggestions = rebalancing_analyzer.suggest_rebalancing(analysis_results, portfolio)
         
         # Получаем общую сводку
-        portfolio_summary = rebalancing_analyzer.get_portfolio_summary(analysis_results)
+        portfolio_summary = rebalancing_analyzer.get_portfolio_summary(analysis_results, portfolio)
 
         total_value = calculate_portfolio_value(
             portfolio,
@@ -104,8 +104,8 @@ async def analyze_portfolio_async(portfolio_dict: dict) -> dict:
         logger.info("Начинаем асинхронный анализ портфеля...")
         analysis_results = await portfolio_analyzer.analyze_portfolio_async(portfolio)
 
-        rebalancing_suggestions = rebalancing_analyzer.suggest_rebalancing(analysis_results)
-        portfolio_summary = rebalancing_analyzer.get_portfolio_summary(analysis_results)
+        rebalancing_suggestions = rebalancing_analyzer.suggest_rebalancing(analysis_results, portfolio)
+        portfolio_summary = rebalancing_analyzer.get_portfolio_summary(analysis_results, portfolio)
 
         total_value = calculate_portfolio_value(
             portfolio,
@@ -163,6 +163,8 @@ def print_analysis_results(results: dict):
     print(f"Общая стратегия: {summary['portfolio_action']}")
     if 'total_value' in summary:
         print(f"Стоимость портфеля: {summary['total_value']:.2f} руб.")
+    if 'cash_rub' in summary:
+        print(f"Свободные средства: {summary['cash_rub']:.2f} руб.")
     
     # Выводим детальные результаты по каждому тикеру
     print("\n" + "="*60)
@@ -195,6 +197,8 @@ def generate_analysis_report(results: dict) -> str:
     lines.append(f"Общая стратегия: {summary['portfolio_action']}")
     if "total_value" in summary:
         lines.append(f"Стоимость портфеля: {summary['total_value']:.2f} руб.")
+    if "cash_rub" in summary:
+        lines.append(f"Свободные средства: {summary['cash_rub']:.2f} руб.")
 
     lines.append("")
     lines.append("=" * 60)

--- a/models/state.py
+++ b/models/state.py
@@ -32,11 +32,17 @@ class PortfolioPosition(BaseModel):
 
 class Portfolio(BaseModel):
     positions: List[PortfolioPosition]
+    cash_rub: float = 0.0
 
     @classmethod
     def from_dict(cls, data: Dict[str, int]):
-        positions = [PortfolioPosition(ticker=k, quantity=v) for k, v in data.items()]
-        return cls(positions=positions)
+        cash = float(data.get("RUB", 0))
+        positions = [
+            PortfolioPosition(ticker=k, quantity=v)
+            for k, v in data.items()
+            if k != "RUB"
+        ]
+        return cls(positions=positions, cash_rub=cash)
 
     def get_tickers(self) -> List[str]:
         return [pos.ticker for pos in self.positions]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -63,6 +63,13 @@ class TestPortfolio:
         tickers = [pos.ticker for pos in portfolio.positions]
         assert "SBER" in tickers
         assert "GAZP" in tickers
+
+    def test_from_dict_with_cash(self):
+        """Тест создания портфеля с наличными"""
+        data = {"SBER": 100, "RUB": 1000}
+        portfolio = Portfolio.from_dict(data)
+        assert len(portfolio.positions) == 1
+        assert portfolio.cash_rub == 1000
     
     def test_from_dict_empty(self):
         """Тест создания пустого портфеля"""

--- a/tests/test_rebalancing.py
+++ b/tests/test_rebalancing.py
@@ -1,0 +1,23 @@
+import pytest
+from analyzers import RebalancingAnalyzer
+from models import Portfolio, PortfolioPosition, AnalysisResult
+
+
+def test_suggest_rebalancing_with_cash():
+    portfolio = Portfolio.from_dict({"AAA": 10, "BBB": 5, "RUB": 1000})
+    analysis_results = {
+        "AAA": AnalysisResult(
+            ticker="AAA", recommendation="ПРОДАВАТЬ", confidence=1.0, analysis_data={}
+        ),
+        "BBB": AnalysisResult(
+            ticker="BBB", recommendation="КУПИТЬ", confidence=1.0, analysis_data={}
+        ),
+    }
+
+    price_data = {"AAA": 100.0, "BBB": 10.0}
+    analyzer = RebalancingAnalyzer(price_getter=lambda t: price_data[t])
+    result = analyzer.suggest_rebalancing(analysis_results, portfolio)
+
+    assert result["AAA"].startswith("Продать")
+    assert result["BBB"].startswith("Купить")
+    assert result["RUB"].startswith("Остаток")

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -56,4 +56,5 @@ def calculate_portfolio_value(portfolio: 'Portfolio', price_getter: Callable[[st
             total += price * position.quantity
         except Exception as e:
             logger.error(f"Price for {position.ticker} unavailable: {e}")
+    total += portfolio.cash_rub
     return total


### PR DESCRIPTION
## Summary
- support cash in portfolio model
- include cash when calculating portfolio value
- improve rebalancing analyzer to give buy/sell amounts and track cash
- display cash balance in reports
- add tests for new cash functionality and rebalancing logic

## Testing
- `pip install -q -r req.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bbbc2f070832fa1343588c80d252d