### PR TITLE
Allow analyzing tickers with zero quantity

### DIFF
--- a/models/state.py
+++ b/models/state.py
@@ -26,8 +26,8 @@ class PortfolioPosition(BaseModel):
     
     @validator('quantity')
     def validate_quantity(cls, v):
-        if v <= 0:
-            raise ValueError('Quantity must be positive')
+        if v < 0:
+            raise ValueError('Quantity must be non-negative')
         return v
 
 class Portfolio(BaseModel):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -29,17 +29,16 @@ class TestPortfolioPosition:
             PortfolioPosition(ticker="", quantity=100)
         assert "at least 3 characters" in str(exc_info.value)
     
-    def test_invalid_quantity_zero(self):
-        """Тест валидации нулевого количества"""
-        with pytest.raises(ValidationError) as exc_info:
-            PortfolioPosition(ticker="SBER", quantity=0)
-        assert "must be positive" in str(exc_info.value)
+    def test_zero_quantity_allowed(self):
+        """Нулевое количество теперь допустимо"""
+        position = PortfolioPosition(ticker="SBER", quantity=0)
+        assert position.quantity == 0
     
     def test_invalid_quantity_negative(self):
         """Тест валидации отрицательного количества"""
         with pytest.raises(ValidationError) as exc_info:
             PortfolioPosition(ticker="SBER", quantity=-10)
-        assert "must be positive" in str(exc_info.value)
+        assert "non-negative" in str(exc_info.value)
 
 
 class TestPortfolio:


### PR DESCRIPTION
## Summary
- permit non-negative quantities in `PortfolioPosition`
- update tests to reflect validator change

## Testing
- `pip install -r req.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bbfa3d9cc832fb8a757cd7fca42d1