### PR TITLE
Add investment risk profile

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@ import json
 import argparse
 from dotenv import load_dotenv
 
-from models import Portfolio
+from models import Portfolio, RiskProfile
 from analyzers import PortfolioAnalyzer, RebalancingAnalyzer, AsyncPortfolioAnalyzer
 from utils import (
     log_performance_summary,
@@ -161,6 +161,8 @@ def print_analysis_results(results: dict):
     print(f"К продаже: {summary['sell_recommendations']}")
     print(f"Средняя уверенность: {summary['average_confidence']:.2f}")
     print(f"Общая стратегия: {summary['portfolio_action']}")
+    if 'risk_profile' in summary:
+        print(f"Тип инвестора: {summary['risk_profile']}")
     if 'total_value' in summary:
         print(f"Стоимость портфеля: {summary['total_value']:.2f} руб.")
     if 'cash_rub' in summary:
@@ -195,6 +197,8 @@ def generate_analysis_report(results: dict) -> str:
     lines.append(f"К продаже: {summary['sell_recommendations']}")
     lines.append(f"Средняя уверенность: {summary['average_confidence']:.2f}")
     lines.append(f"Общая стратегия: {summary['portfolio_action']}")
+    if "risk_profile" in summary:
+        lines.append(f"Тип инвестора: {summary['risk_profile']}")
     if "total_value" in summary:
         lines.append(f"Стоимость портфеля: {summary['total_value']:.2f} руб.")
     if "cash_rub" in summary:
@@ -242,12 +246,20 @@ if __name__ == "__main__":
         default="portfolio.json",
         help="Путь к JSON-файлу с портфелем",
     )
+    parser.add_argument(
+        "-r",
+        "--risk-profile",
+        default=RiskProfile.BALANCED.value,
+        choices=[p.value for p in RiskProfile],
+        help="Тип инвестирования",
+    )
     args = parser.parse_args()
 
     start_time = datetime.now()
 
     try:
         portfolio_data = load_portfolio_from_file(args.file)
+        portfolio_data["risk_profile"] = args.risk_profile
     except Exception as e:
         logger.error(f"Ошибка чтения портфеля из файла: {e}")
         raise SystemExit(1)

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,3 +1,15 @@
-from .state import State, Portfolio, PortfolioPosition, AnalysisResult
+from .state import (
+    State,
+    Portfolio,
+    PortfolioPosition,
+    AnalysisResult,
+    RiskProfile,
+)
 
-__all__ = ['State', 'Portfolio', 'PortfolioPosition', 'AnalysisResult']
+__all__ = [
+    'State',
+    'Portfolio',
+    'PortfolioPosition',
+    'AnalysisResult',
+    'RiskProfile',
+]

--- a/tests/test_async_analyzer.py
+++ b/tests/test_async_analyzer.py
@@ -8,7 +8,7 @@ from models import Portfolio, PortfolioPosition, AnalysisResult
 async def test_analyze_portfolio_async(monkeypatch):
     analyzer = AsyncPortfolioAnalyzer(max_concurrent_tasks=2)
 
-    async def fake_analyze_single(chain, position):
+    async def fake_analyze_single(chain, position, risk_profile):
         await asyncio.sleep(0.01)
         return position.ticker, AnalysisResult(
             ticker=position.ticker,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,6 +1,6 @@
 import pytest
 from pydantic import ValidationError
-from models.state import Portfolio, PortfolioPosition, AnalysisResult
+from models.state import Portfolio, PortfolioPosition, AnalysisResult, RiskProfile
 
 
 class TestPortfolioPosition:
@@ -62,6 +62,15 @@ class TestPortfolio:
         tickers = [pos.ticker for pos in portfolio.positions]
         assert "SBER" in tickers
         assert "GAZP" in tickers
+
+    def test_risk_profile_default(self):
+        portfolio = Portfolio.from_dict({"SBER": 1})
+        assert portfolio.risk_profile == RiskProfile.BALANCED
+
+    def test_risk_profile_custom(self):
+        data = {"SBER": 1, "risk_profile": "агрессивный"}
+        portfolio = Portfolio.from_dict(data)
+        assert portfolio.risk_profile == RiskProfile.AGGRESSIVE
 
     def test_from_dict_with_cash(self):
         """Тест создания портфеля с наличными"""


### PR DESCRIPTION
## Summary
- support risk profile (conservative/balanced/aggressive)
- use risk profile in portfolio analyzers and reports
- expose new CLI option `--risk-profile`
- update tests for risk profile handling

## Testing
- `pip install -r req.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bc2f2c160832fb3fc2803cf6d242b