### PR TITLE
Add final actions table

### DIFF
--- a/main.py
+++ b/main.py
@@ -180,6 +180,13 @@ def print_analysis_results(results: dict):
         print(f"   Решение: {data['decision']}...")
         print(f"   Ребалансировка: {results['rebalancing_suggestions'][ticker]}")
 
+    # Итоговая таблица действий
+    print("\n" + "="*60)
+    print("📋 ИТОГОВАЯ ТАБЛИЦА ДЕЙСТВИЙ")
+    print("="*60)
+    for ticker, action in results["rebalancing_suggestions"].items():
+        print(f"{ticker:<6} {action}")
+
 
 def generate_analysis_report(results: dict) -> str:
     """Формирует текстовый отчет по результатам анализа."""
@@ -217,6 +224,13 @@ def generate_analysis_report(results: dict) -> str:
         )
         lines.append(f"   Решение: {data['decision']}...")
         lines.append(f"   Ребалансировка: {results['rebalancing_suggestions'][ticker]}")
+
+    lines.append("")
+    lines.append("=" * 60)
+    lines.append("📋 ИТОГОВАЯ ТАБЛИЦА ДЕЙСТВИЙ")
+    lines.append("=" * 60)
+    for ticker, action in results["rebalancing_suggestions"].items():
+        lines.append(f"{ticker:<6} {action}")
 
     return "\n".join(lines)
 

--- a/tests/test_report_actions.py
+++ b/tests/test_report_actions.py
@@ -1,0 +1,48 @@
+import pytest
+from main import generate_analysis_report
+
+
+def test_actions_table_in_report():
+    results = {
+        "analysis_results": {
+            "MGNT": {
+                "quantity": 10,
+                "recommendation": "ДЕРЖАТЬ",
+                "confidence": 0.8,
+                "decision": "",
+                "details": {}
+            },
+            "SBER": {
+                "quantity": 5,
+                "recommendation": "КУПИТЬ",
+                "confidence": 0.8,
+                "decision": "",
+                "details": {}
+            },
+        },
+        "rebalancing_suggestions": {
+            "MGNT": "Держать",
+            "SBER": "Купить 150",
+            "TRNFP": "Продать 20",
+            "RUB": "Остаток 1000"
+        },
+        "portfolio_summary": {
+            "total_positions": 2,
+            "buy_recommendations": 1,
+            "sell_recommendations": 1,
+            "hold_recommendations": 0,
+            "average_confidence": 0.8,
+            "portfolio_action": "",
+            "cash_rub": 1000,
+        },
+    }
+
+    report = generate_analysis_report(results)
+    assert "MGNT" in report
+    assert "Держать" in report
+    assert "SBER" in report
+    assert "Купить 150" in report
+    assert "TRNFP" in report
+    assert "Продать 20" in report
+    assert "RUB" in report
+    assert "Остаток 1000" in report


### PR DESCRIPTION
## Summary
- print a final actions table in the report
- extend report generator to include table
- test the new table output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bce845148832f8ca231b9db6e282d