### PR TITLE
Fix report saving on errors

### DIFF
--- a/analyzers/rebalancing_analyzer.py
+++ b/analyzers/rebalancing_analyzer.py
@@ -58,7 +58,13 @@ class RebalancingAnalyzer:
                 rebalancing_suggestions[ticker] = "Позиция отсутствует"
                 continue
             qty = position.quantity
-            price = self.price_getter(ticker)
+            try:
+                price = self.price_getter(ticker)
+            except Exception as e:
+                logger.error(f"Failed to get price for {ticker}: {e}")
+                rebalancing_suggestions[ticker] = "Цена недоступна"
+                continue
+
             proceeds = price * qty * (1 - self.BROKER_FEE)
             proceeds_after_tax = proceeds * (1 - self.TAX_RATE)
             cash += proceeds_after_tax
@@ -68,7 +74,13 @@ class RebalancingAnalyzer:
         buy_tickers = [t for t, r in analysis_results.items() if r.recommendation == "КУПИТЬ"]
         buy_count = len(buy_tickers)
         for ticker in buy_tickers:
-            price = self.price_getter(ticker)
+            try:
+                price = self.price_getter(ticker)
+            except Exception as e:
+                logger.error(f"Failed to get price for {ticker}: {e}")
+                rebalancing_suggestions[ticker] = "Цена недоступна"
+                continue
+
             cash_per_ticker = cash / buy_count if buy_count else 0
             qty = int(cash_per_ticker / (price * (1 + self.BROKER_FEE)))
             if qty > 0:

--- a/main.py
+++ b/main.py
@@ -281,8 +281,17 @@ if __name__ == "__main__":
     print("🚀 Запуск улучшенного анализа портфеля (async)...")
     print(f"Анализируемый портфель: {portfolio_data}")
 
-    results = asyncio.run(analyze_portfolio_async(portfolio_data))
-
+    try:
+        results = asyncio.run(analyze_portfolio_async(portfolio_data))
+    except Exception as e:
+        logger.error(f"Critical error during analysis: {e}")
+        results = {
+            "error": str(e),
+            "analysis_results": {},
+            "rebalancing_suggestions": {},
+            "portfolio_summary": {"error": "Ошибка анализа"},
+        }
+    
     # Выводим результаты
     print_analysis_results(results)
 


### PR DESCRIPTION
## Summary
- handle price lookup errors gracefully in `RebalancingAnalyzer`
- keep main script from aborting on unexpected exceptions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cb69bc068832f9fa9cad1a128b673