### PR TITLE
Fix ticker validation to allow 2 characters

### DIFF
--- a/models/state.py
+++ b/models/state.py
@@ -22,8 +22,8 @@ class PortfolioPosition(BaseModel):
     
     @validator('ticker')
     def validate_ticker(cls, v):
-        if not v or len(v) < 3:
-            raise ValueError('Ticker must be at least 3 characters')
+        if not v or len(v) < 2:
+            raise ValueError('Ticker must be at least 2 characters')
         return v.upper()
     
     @validator('quantity')

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -20,14 +20,14 @@ class TestPortfolioPosition:
     def test_invalid_ticker_too_short(self):
         """Тест валидации слишком короткого тикера"""
         with pytest.raises(ValidationError) as exc_info:
-            PortfolioPosition(ticker="AB", quantity=100)
-        assert "at least 3 characters" in str(exc_info.value)
+            PortfolioPosition(ticker="A", quantity=100)
+        assert "at least 2 characters" in str(exc_info.value)
     
     def test_invalid_ticker_empty(self):
         """Тест валидации пустого тикера"""
         with pytest.raises(ValidationError) as exc_info:
             PortfolioPosition(ticker="", quantity=100)
-        assert "at least 3 characters" in str(exc_info.value)
+        assert "at least 2 characters" in str(exc_info.value)
     
     def test_zero_quantity_allowed(self):
         """Нулевое количество теперь допустимо"""


### PR DESCRIPTION
## Summary
- relax ticker validation to accept two-character symbols
- update tests for new minimum length

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cf4fd9650832facebbd47f2de65ed