### PR TITLE
Add PMPT metrics

### DIFF
--- a/tests/test_pmpt.py
+++ b/tests/test_pmpt.py
@@ -1,0 +1,24 @@
+import numpy as np
+import pytest
+
+from utils.pmpt import downside_risk, sortino_ratio, omega_ratio
+
+
+def test_downside_risk():
+    returns = [0.05, -0.02, 0.03, -0.01, 0.04]
+    expected = np.sqrt(((-0.02) ** 2 + (-0.01) ** 2) / 5)
+    assert downside_risk(returns) == pytest.approx(expected)
+
+
+def test_sortino_ratio():
+    returns = [0.1, 0.0, -0.05, 0.07]
+    avg = np.mean(returns)
+    dr = downside_risk(returns)
+    assert sortino_ratio(returns) == pytest.approx(avg / dr)
+
+
+def test_omega_ratio():
+    returns = [0.1, -0.02, 0.04, -0.01]
+    gains = 0.1 + 0.04
+    losses = 0.02 + 0.01
+    assert omega_ratio(returns) == pytest.approx(gains / losses)

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -6,7 +6,13 @@ from .helpers import (
     truncate_text,
     calculate_portfolio_value,
 )
-from .monitoring import monitor_performance, get_performance_report, log_performance_summary, performance_monitor
+from .monitoring import (
+    monitor_performance,
+    get_performance_report,
+    log_performance_summary,
+    performance_monitor,
+)
+from .pmpt import downside_risk, sortino_ratio, omega_ratio
 
 __all__ = [
     'APIError',
@@ -19,4 +25,7 @@ __all__ = [
     'get_performance_report',
     'log_performance_summary',
     'performance_monitor',
+    'downside_risk',
+    'sortino_ratio',
+    'omega_ratio',
 ]

--- a/utils/pmpt.py
+++ b/utils/pmpt.py
@@ -1,0 +1,59 @@
+"""Functions for Post-Modern Portfolio Theory metrics."""
+
+from __future__ import annotations
+
+import numpy as np
+from typing import Iterable
+
+
+def downside_risk(returns: Iterable[float], target: float = 0.0, periods_per_year: int | None = None) -> float:
+    """Calculate downside risk of a return series.
+
+    Parameters
+    ----------
+    returns : Iterable[float]
+        Sequence of periodic returns.
+    target : float, optional
+        Minimum acceptable return. Defaults to ``0.0``.
+    periods_per_year : int | None, optional
+        If provided, annualizes the risk by ``sqrt(periods_per_year)``.
+
+    Returns
+    -------
+    float
+        Downside risk value.
+    """
+    arr = np.asarray(list(returns), dtype=float)
+    downside = np.minimum(0, arr - target)
+    variance = np.mean(downside ** 2)
+    risk = float(np.sqrt(variance))
+    if periods_per_year:
+        risk *= np.sqrt(periods_per_year)
+    return risk
+
+
+def sortino_ratio(
+    returns: Iterable[float],
+    target: float = 0.0,
+    risk_free: float = 0.0,
+    periods_per_year: int | None = None,
+) -> float:
+    """Calculate Sortino ratio for a series of returns."""
+    arr = np.asarray(list(returns), dtype=float)
+    excess = arr - risk_free
+    avg_return = float(np.mean(excess))
+    dr = downside_risk(arr, target=target, periods_per_year=periods_per_year)
+    if dr == 0:
+        return np.nan
+    return avg_return / dr
+
+
+def omega_ratio(returns: Iterable[float], target: float = 0.0) -> float:
+    """Calculate Omega ratio for a series of returns."""
+    arr = np.asarray(list(returns), dtype=float)
+    excess = arr - target
+    gains = excess[excess > 0].sum()
+    losses = -excess[excess < 0].sum()
+    if losses == 0:
+        return np.inf
+    return float(gains / losses)


### PR DESCRIPTION
## Summary
- provide Post-Modern Portfolio Theory helpers
- export helpers in utils
- test downside risk, Sortino and Omega ratios

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880c7558cf8832f870ef36f22eb633a