### PR TITLE
Add PMPT metrics output for portfolio assets

### DIFF
--- a/analyzers/async_portfolio_analyzer.py
+++ b/analyzers/async_portfolio_analyzer.py
@@ -14,6 +14,7 @@ from models.state import (
 )
 from .portfolio_analyzer import PortfolioAnalyzer
 from utils.helpers import extract_recommendation
+from utils.pmpt import pmpt_metrics
 
 logger = logging.getLogger(__name__)
 
@@ -58,6 +59,12 @@ class AsyncPortfolioAnalyzer(PortfolioAnalyzer):
                     "final_decision": result.get("final_data", ""),
                 },
             )
+            try:
+                returns = self.moex_service.get_returns(position.ticker)
+                analysis_result.analysis_data["pmpt"] = pmpt_metrics(returns)
+            except Exception as e:
+                logger.error(f"Failed to compute PMPT for {position.ticker}: {e}")
+                analysis_result.analysis_data["pmpt"] = {}
             return position.ticker, analysis_result
 
     async def analyze_portfolio_async(self, portfolio: Portfolio) -> Dict[str, AnalysisResult]:

--- a/analyzers/portfolio_analyzer.py
+++ b/analyzers/portfolio_analyzer.py
@@ -17,6 +17,7 @@ from utils.helpers import (
     truncate_text,
     extract_recommendation,
 )
+from utils.pmpt import pmpt_metrics
 
 logger = logging.getLogger(__name__)
 
@@ -240,6 +241,13 @@ class PortfolioAnalyzer:
                         "final_decision": result["final_data"]
                     }
                 )
+
+                try:
+                    returns = self.moex_service.get_returns(position.ticker)
+                    analysis_result.analysis_data["pmpt"] = pmpt_metrics(returns)
+                except Exception as e:
+                    logger.error(f"Failed to compute PMPT for {position.ticker}: {e}")
+                    analysis_result.analysis_data["pmpt"] = {}
                 
                 portfolio_results[position.ticker] = analysis_result
                 

--- a/main.py
+++ b/main.py
@@ -78,7 +78,8 @@ def analyze_portfolio_improved(portfolio_dict: dict) -> dict:
                     "market_news": result.analysis_data.get("market_news", ""),
                     "company_news": result.analysis_data.get("semantic", ""),
                     "technical_analysis": result.analysis_data.get("moex_analysis", ""),
-                    "financial_data": result.analysis_data.get("ifrs_data", "")
+                    "financial_data": result.analysis_data.get("ifrs_data", ""),
+                    "pmpt": result.analysis_data.get("pmpt", {}),
                 }
             }
         
@@ -130,6 +131,7 @@ async def analyze_portfolio_async(portfolio_dict: dict) -> dict:
                     "company_news": result.analysis_data.get("semantic", ""),
                     "technical_analysis": result.analysis_data.get("moex_analysis", ""),
                     "financial_data": result.analysis_data.get("ifrs_data", ""),
+                    "pmpt": result.analysis_data.get("pmpt", {}),
                 },
             }
 
@@ -178,6 +180,17 @@ def print_analysis_results(results: dict):
         print(f"   Количество: {data['quantity']}")
         print(f"   Решение: {data['decision']}...")
         print(f"   Ребалансировка: {results['rebalancing_suggestions'][ticker]}")
+        pmpt = data['details'].get('pmpt', {})
+        if pmpt:
+            print(
+                f"   Downside risk: {pmpt.get('downside_risk', float('nan')):.4f}"
+            )
+            print(
+                f"   Sortino ratio: {pmpt.get('sortino_ratio', float('nan')):.4f}"
+            )
+            print(
+                f"   Omega ratio: {pmpt.get('omega_ratio', float('nan')):.4f}"
+            )
 
     # Итоговая таблица действий
     print("\n" + "="*60)
@@ -220,6 +233,11 @@ def generate_analysis_report(results: dict) -> str:
         lines.append(f"   Количество: {data['quantity']}")
         lines.append(f"   Решение: {data['decision']}...")
         lines.append(f"   Ребалансировка: {results['rebalancing_suggestions'][ticker]}")
+        pmpt = data['details'].get('pmpt', {})
+        if pmpt:
+            lines.append(f"   Downside risk: {pmpt.get('downside_risk', float('nan')):.4f}")
+            lines.append(f"   Sortino ratio: {pmpt.get('sortino_ratio', float('nan')):.4f}")
+            lines.append(f"   Omega ratio: {pmpt.get('omega_ratio', float('nan')):.4f}")
 
     lines.append("")
     lines.append("=" * 60)

--- a/services/moex_service.py
+++ b/services/moex_service.py
@@ -79,3 +79,13 @@ class MOEXService:
         except Exception as e:
             logger.error(f"Failed to get latest price for {ticker}: {e}")
             raise APIError(f"Failed to get latest price for {ticker}: {e}")
+
+    def get_returns(self, ticker: str, days_back: Optional[int] = None) -> list[float]:
+        """Возвращает ряд доходностей по закрытиям."""
+        try:
+            df = self.get_ticker_data(ticker, days_back=days_back)
+            returns = df['CLOSE'].pct_change().dropna().tolist()
+            return [float(r) for r in returns]
+        except Exception as e:
+            logger.error(f"Failed to get returns for {ticker}: {e}")
+            raise APIError(f"Failed to get returns for {ticker}: {e}")

--- a/tests/test_pmpt.py
+++ b/tests/test_pmpt.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from utils.pmpt import downside_risk, sortino_ratio, omega_ratio
+from utils.pmpt import downside_risk, sortino_ratio, omega_ratio, pmpt_metrics
 
 
 def test_downside_risk():
@@ -22,3 +22,10 @@ def test_omega_ratio():
     gains = 0.1 + 0.04
     losses = 0.02 + 0.01
     assert omega_ratio(returns) == pytest.approx(gains / losses)
+
+
+def test_pmpt_metrics():
+    returns = [0.05, 0.0, -0.05, 0.07]
+    metrics = pmpt_metrics(returns)
+    assert set(metrics.keys()) == {"downside_risk", "sortino_ratio", "omega_ratio"}
+    assert metrics["sortino_ratio"] == pytest.approx(sortino_ratio(returns))

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -12,7 +12,7 @@ from .monitoring import (
     log_performance_summary,
     performance_monitor,
 )
-from .pmpt import downside_risk, sortino_ratio, omega_ratio
+from .pmpt import downside_risk, sortino_ratio, omega_ratio, pmpt_metrics
 
 __all__ = [
     'APIError',
@@ -28,4 +28,5 @@ __all__ = [
     'downside_risk',
     'sortino_ratio',
     'omega_ratio',
+    'pmpt_metrics',
 ]

--- a/utils/pmpt.py
+++ b/utils/pmpt.py
@@ -57,3 +57,25 @@ def omega_ratio(returns: Iterable[float], target: float = 0.0) -> float:
     if losses == 0:
         return np.inf
     return float(gains / losses)
+
+
+def pmpt_metrics(returns: Iterable[float]) -> dict:
+    """Return basic PMPT metrics for a series of returns.
+
+    Parameters
+    ----------
+    returns : Iterable[float]
+        Periodic returns, usually daily.
+
+    Returns
+    -------
+    dict
+        Dictionary with ``downside_risk``, ``sortino_ratio`` and ``omega_ratio``.
+    """
+
+    arr = list(returns)
+    return {
+        "downside_risk": downside_risk(arr),
+        "sortino_ratio": sortino_ratio(arr),
+        "omega_ratio": omega_ratio(arr),
+    }


### PR DESCRIPTION
## Summary
- expose `pmpt_metrics` helper and export it
- add daily returns calculation in `MOEXService`
- compute PMPT metrics in analyzers
- include PMPT metrics in report generation
- test new `pmpt_metrics` helper

## Testing
- `pip install -r req.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880cb468ad4832fa675418ff12ef209