### PR TITLE
Allow nested analysis data in AnalysisResult

### DIFF
--- a/models/state.py
+++ b/models/state.py
@@ -1,6 +1,6 @@
 from typing_extensions import TypedDict
 from pydantic import BaseModel, validator
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Any
 from dataclasses import dataclass
 from enum import Enum
 
@@ -85,7 +85,7 @@ class AnalysisResult(BaseModel):
     ticker: str
     recommendation: str
     confidence: float
-    analysis_data: Dict[str, str]
+    analysis_data: Dict[str, Any]
 
     @validator('confidence')
     def validate_confidence(cls, v):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -152,3 +152,14 @@ class TestAnalysisResult:
                 ticker="SBER", recommendation="КУПИТЬ", 
                 confidence=1.1, analysis_data={}
             )
+
+    def test_analysis_data_allows_nested_dict(self):
+        """Проверяем, что analysis_data поддерживает вложенные структуры"""
+        nested_data = {"agent_votes": {"agent1": "BUY"}, "pmpt": {"sortino": 1.2}}
+        result = AnalysisResult(
+            ticker="GAZP",
+            recommendation="ДЕРЖАТЬ",
+            confidence=0.5,
+            analysis_data=nested_data,
+        )
+        assert result.analysis_data == nested_data


### PR DESCRIPTION
## Summary
- allow `AnalysisResult.analysis_data` to hold nested structures by using `Dict[str, Any]`
- add test covering nested `analysis_data`

## Testing
- `pytest` *(fails: No module named 'openai', No module named 'langsmith')*


------
https://chatgpt.com/codex/tasks/task_e_689a40c6252c832fb6b36aba71b4c1ec