### PR TITLE
Enable LangSmith tracing of LLM calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,9 @@ pip install -r requirements.txt
 Создайте файл `.env` и укажите обязательный ключ API:
 ```env
 DEEPSEEK_API_KEY=your_actual_key
-DEEPSEEK_MODEL=deepseek-reasoner или deepseek-chat 
+DEEPSEEK_MODEL=deepseek-reasoner или deepseek-chat
+# Опционально: включение трасировки LangSmith
+LANGCHAIN_API_KEY=your_langsmith_key
 ```
 Дополнительные переменные могут быть заданы по желанию. Неизвестные
 переменные будут просто игнорироваться при загрузке настроек.

--- a/services/ai_service.py
+++ b/services/ai_service.py
@@ -1,7 +1,10 @@
 import logging
-from openai import OpenAI
-from typing import Optional
 import os
+from typing import Optional
+
+from openai import OpenAI
+from langsmith.wrappers import wrap_openai
+
 from config import settings
 from utils.helpers import retry_on_failure, APIError
 from utils.monitoring import monitor_performance
@@ -20,10 +23,13 @@ class AIService:
 
     def _ensure_client(self):
         if self.client is None:
-            self.client = OpenAI(
+            client = OpenAI(
                 api_key=self.api_key,
                 base_url=settings.deepseek_base_url,
             )
+            if os.getenv("LANGCHAIN_API_KEY") or os.getenv("LANGSMITH_API_KEY"):
+                client = wrap_openai(client)
+            self.client = client
     
     @monitor_performance("ai_service")
     @retry_on_failure(max_retries=settings.max_retries)

--- a/tests/test_ai_service.py
+++ b/tests/test_ai_service.py
@@ -1,5 +1,6 @@
 import pytest
-from unittest.mock import Mock, patch, MagicMock
+from unittest.mock import Mock, patch
+
 from services.ai_service import AIService
 from utils.helpers import APIError
 
@@ -70,3 +71,13 @@ class TestAIService:
         with patch('time.sleep'):  # Мокаем sleep для ускорения тестов
             result = ai_service.call_deepseek("system", "user")
             assert "Success after retry" in result or "Ошибка анализа" in result
+
+    @patch('services.ai_service.wrap_openai')
+    @patch('services.ai_service.OpenAI')
+    def test_wrap_openai_called_when_langsmith_enabled(self, mock_openai, mock_wrap):
+        """Проверяем, что wrap_openai вызывается при активном LangSmith"""
+        mock_openai.return_value.chat.completions.create.return_value = Mock(choices=[Mock(message=Mock(content="resp"))])
+        with patch.dict('os.environ', {'DEEPSEEK_API_KEY': 'test_key', 'LANGCHAIN_API_KEY': 'ls_key'}):
+            service = AIService()
+            service.call_deepseek("sys", "usr")
+        mock_wrap.assert_called_once()


### PR DESCRIPTION
## Summary
- wrap OpenAI client with LangSmith when configured to emit traces
- cover tracing integration in AIService tests
- document optional LangSmith tracing in README

## Testing
- `pytest`

------
