### PR TITLE
feat: add local ollama option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Анализ портфеля акций
 
-Этот проект представляет собой инструмент для анализа портфеля акций, использующий данные из различных источников (Tinkoff Pulse, MOEX, новостные ленты, отчетность МСФО) и искусственный интеллект (DeepSeek API) для формирования инвестиционных рекомендаций.
+Этот проект представляет собой инструмент для анализа портфеля акций, использующий данные из различных источников (Tinkoff Pulse, MOEX, новостные ленты, отчетность МСФО) и искусственный интеллект (DeepSeek API или локальный Ollama) для формирования инвестиционных рекомендаций.
 
 ## Основные возможности
 - Сбор новостей по тикерам из Tinkoff Pulse
@@ -49,10 +49,18 @@ python main.py --file portfolio.json --risk-profile тип_портфеля
 pip install -r requirements.txt
 ```
 
-Создайте файл `.env` и укажите обязательный ключ API:
+Создайте файл `.env` и укажите необходимые ключи и настройки:
 ```env
+LLM_PROVIDER=deepseek                 # или 'ollama'
+
+# DeepSeek
 DEEPSEEK_API_KEY=your_actual_key
 DEEPSEEK_MODEL=deepseek-reasoner или deepseek-chat
+
+# Локальная Ollama
+OLLAMA_MODEL=llama3:8b
+OLLAMA_BASE_URL=http://localhost:11434
+
 # Опционально: включение трасировки LangSmith
 LANGCHAIN_API_KEY=your_langsmith_key
 ```

--- a/SETUP.md
+++ b/SETUP.md
@@ -13,7 +13,7 @@ portfolio_analyzer/
 │   └── state.py           # Portfolio, AnalysisResult
 ├── services/              # Сервисный слой
 │   ├── __init__.py
-│   ├── ai_service.py      # DeepSeek API
+│   ├── ai_service.py      # LLM API (DeepSeek/Ollama)
 │   ├── news_service.py    # Новости (Lenta.ru, Tinkoff Pulse)
 │   ├── moex_service.py    # Данные MOEX
 │   └── ifrs_service.py    # IFRS отчетность
@@ -56,10 +56,17 @@ cp .env.example .env
 
 Отредактируйте `.env`:
 ```env
+# LLM provider configuration
+LLM_PROVIDER=deepseek              # или 'ollama'
+
 # DeepSeek API Configuration
 DEEPSEEK_API_KEY=your_actual_api_key_here
 DEEPSEEK_MODEL=deepseek-chat
 DEEPSEEK_BASE_URL=https://api.deepseek.com
+
+# Local Ollama configuration
+OLLAMA_MODEL=llama3:8b
+OLLAMA_BASE_URL=http://localhost:11434
 
 # Analysis Parameters
 NEWS_DAYS_LOOKBACK=1

--- a/analyzers/hedge_fund_agents.py
+++ b/analyzers/hedge_fund_agents.py
@@ -43,7 +43,7 @@ class HedgeFundAgents:
                     "Ответь в формате: КУПИТЬ/ДЕРЖАТЬ/ПРОДАТЬ и короткое обоснование."
                 )
                 user_prompt = f"Анализ по {ticker}:\n{summary}"
-                response = self.ai_service.call_deepseek(system_prompt, user_prompt)
+                response = self.ai_service.call_model(system_prompt, user_prompt)
                 votes[agent.name] = extract_recommendation(response)
             except Exception as e:
                 logger.error(f"Agent {agent.name} failed: {e}")

--- a/analyzers/portfolio_analyzer.py
+++ b/analyzers/portfolio_analyzer.py
@@ -41,7 +41,7 @@ class PortfolioAnalyzer:
                 system_prompt = "Анализ новостей рынка. Формат: Настрой, Факторы, Влияние"
                 user_prompt = f"Новости:\n{news_entries}"
                 
-                analysis = self.ai_service.call_deepseek(system_prompt, user_prompt)
+                analysis = self.ai_service.call_model(system_prompt, user_prompt)
                 return {"market_news": analysis}
             
             return {"market_news": "Недостаточно свежих новостей для анализа"}
@@ -70,7 +70,7 @@ class PortfolioAnalyzer:
             system_prompt = "Анализ новостей компании. Формат: Настрой, Ключевое, Риски"
             user_prompt = f"Новости {state['ticker']}:\n{state['news']}"
             
-            analysis = self.ai_service.call_deepseek(system_prompt, user_prompt)
+            analysis = self.ai_service.call_model(system_prompt, user_prompt)
             return {"semantic": analysis}
             
         except (APIError, Exception) as e:
@@ -100,7 +100,7 @@ class PortfolioAnalyzer:
             recent_data = self.moex_service.get_recent_data(state['ticker'], 180)
             user_prompt = f"Данные {state['ticker']}:\n{recent_data}"
             
-            analysis = self.ai_service.call_deepseek(system_prompt, user_prompt)
+            analysis = self.ai_service.call_model(system_prompt, user_prompt)
             return {"moex_data_analysis": analysis}
             
         except (APIError, Exception) as e:
@@ -119,7 +119,7 @@ class PortfolioAnalyzer:
             system_prompt = "Анализ МСФО. Формат: Финансы, Рентабельность, Долги"
             user_prompt = f"Отчетность {state['ticker']}:\n{ifrs_content}"
             
-            analysis = self.ai_service.call_deepseek(system_prompt, user_prompt)
+            analysis = self.ai_service.call_model(system_prompt, user_prompt)
             return {"ifrs_data": analysis}
             
         except (APIError, DataProcessingError, Exception) as e:
@@ -162,7 +162,7 @@ class PortfolioAnalyzer:
                 f"Тип инвестора: {risk}. {goal_map.get(risk, '')}"
             )
 
-            analysis = self.ai_service.call_deepseek(system_prompt, user_prompt)
+            analysis = self.ai_service.call_model(system_prompt, user_prompt)
 
             # Мультиагентный анализ в стиле AI Hedge Fund
             try:

--- a/code_analysis_and_improvements.md
+++ b/code_analysis_and_improvements.md
@@ -83,13 +83,17 @@ class DataProcessingError(Exception):
 
 #### Рекомендации:
 ```python
+import os
 from pydantic import BaseSettings, validator
 from typing import Optional
 
 class Settings(BaseSettings):
-    deepseek_api_key: str
+    llm_provider: str = os.getenv("LLM_PROVIDER", "deepseek")
+    deepseek_api_key: str = os.getenv("DEEPSEEK_API_KEY", "")
     deepseek_model: str = "deepseek-chat"
     deepseek_base_url: str = "https://api.deepseek.com"
+    ollama_model: str = os.getenv("OLLAMA_MODEL", "llama3:8b")
+    ollama_base_url: str = os.getenv("OLLAMA_BASE_URL", "http://localhost:11434")
     
     # Параметры анализа
     news_days_lookback: int = 1
@@ -105,8 +109,8 @@ class Settings(BaseSettings):
         env_file = ".env"
         
     @validator('deepseek_api_key')
-    def validate_api_key(cls, v):
-        if not v:
+    def validate_api_key(cls, v, values):
+        if values.get('llm_provider') == 'deepseek' and not v:
             raise ValueError('DEEPSEEK_API_KEY must be set')
         return v
 
@@ -208,21 +212,21 @@ class TestAIService:
         return AIService(api_key="test_key")
     
     @patch('portfolio_analyzer.services.ai_service.OpenAI')
-    def test_call_deepseek_success(self, mock_openai, ai_service):
+    def test_call_model_success(self, mock_openai, ai_service):
         # Мок успешного ответа
         mock_response = Mock()
         mock_response.choices[0].message.content = "Test response"
         mock_openai.return_value.chat.completions.create.return_value = mock_response
         
-        result = ai_service.call_deepseek("system", "user")
+        result = ai_service.call_model("system", "user")
         assert result == "Test response"
     
     @patch('portfolio_analyzer.services.ai_service.OpenAI')
-    def test_call_deepseek_api_error(self, mock_openai, ai_service):
+    def test_call_model_api_error(self, mock_openai, ai_service):
         # Тест обработки ошибок API
         mock_openai.return_value.chat.completions.create.side_effect = Exception("API Error")
         
-        result = ai_service.call_deepseek("system", "user")
+        result = ai_service.call_model("system", "user")
         assert "Ошибка анализа" in result
 ```
 

--- a/config.py
+++ b/config.py
@@ -1,6 +1,5 @@
 import os
 from pydantic_settings import BaseSettings, SettingsConfigDict
-from pydantic import validator
 
 
 class Settings(BaseSettings):
@@ -9,9 +8,14 @@ class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_file=".env", extra="ignore")
 
     log_level: str = "INFO"  # Default value
-    deepseek_api_key: str = os.getenv("DEEPSEEK_API_KEY", "dummy")
+
+    # LLM provider configuration
+    llm_provider: str = os.getenv("LLM_PROVIDER", "deepseek")
+    deepseek_api_key: str | None = os.getenv("DEEPSEEK_API_KEY")
     deepseek_model: str = "deepseek-chat"
     deepseek_base_url: str = "https://api.deepseek.com"
+    ollama_model: str = os.getenv("OLLAMA_MODEL", "llama3:8b")
+    ollama_base_url: str = os.getenv("OLLAMA_BASE_URL", "http://localhost:11434")
     
     # Параметры анализа
     news_days_lookback: int = 1
@@ -23,10 +27,5 @@ class Settings(BaseSettings):
     api_timeout: int = 30
     max_retries: int = 3
     
-    @validator('deepseek_api_key')
-    def validate_api_key(cls, v):
-        if not v:
-            raise ValueError('DEEPSEEK_API_KEY must be set')
-        return v
 
 settings = Settings()

--- a/services/ai_service.py
+++ b/services/ai_service.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from typing import Optional
+from typing import Optional, Any
 
 from openai import OpenAI
 from langsmith.wrappers import wrap_openai
@@ -12,53 +12,60 @@ from utils.monitoring import monitor_performance
 logger = logging.getLogger(__name__)
 
 class AIService:
-    """Сервис для работы с DeepSeek API"""
-    
+    """Сервис для работы с LLM провайдерами (DeepSeek или локальная Ollama)"""
+
     def __init__(self, api_key: Optional[str] = None):
-        env_key = os.getenv("DEEPSEEK_API_KEY")
-        self.api_key = api_key or env_key
-        if not self.api_key:
-            raise ValueError("DEEPSEEK_API_KEY must be set")
-        self.client: Optional[OpenAI] = None
+        self.provider = settings.llm_provider.lower()
+        if self.provider == "deepseek":
+            env_key = os.getenv("DEEPSEEK_API_KEY")
+            self.api_key = api_key or env_key
+            if not self.api_key:
+                raise ValueError("DEEPSEEK_API_KEY must be set")
+        else:
+            self.api_key = None
+        self.client: Optional[Any] = None
 
     def _ensure_client(self):
         if self.client is None:
-            client = OpenAI(
-                api_key=self.api_key,
-                base_url=settings.deepseek_base_url,
-            )
-            if os.getenv("LANGCHAIN_API_KEY") or os.getenv("LANGSMITH_API_KEY"):
-                client = wrap_openai(client)
-            self.client = client
+            if self.provider == "deepseek":
+                client = OpenAI(
+                    api_key=self.api_key,
+                    base_url=settings.deepseek_base_url,
+                )
+                if os.getenv("LANGCHAIN_API_KEY") or os.getenv("LANGSMITH_API_KEY"):
+                    client = wrap_openai(client)
+                self.client = client
+            elif self.provider == "ollama":
+                from ollama import Client as OllamaClient
+
+                self.client = OllamaClient(host=settings.ollama_base_url)
     
     @monitor_performance("ai_service")
     @retry_on_failure(max_retries=settings.max_retries)
-    def call_deepseek(self, system_prompt: str, user_prompt: str) -> str:
-        """
-        Унифицированный вызов DeepSeek API с поддержкой Context Caching
-        
-        Args:
-            system_prompt: Системное сообщение
-            user_prompt: Пользовательское сообщение
-            
-        Returns:
-            Ответ от API
-            
-        Raises:
-            APIError: При ошибках API
-        """
+    def call_model(self, system_prompt: str, user_prompt: str) -> str:
+        """Унифицированный вызов LLM"""
         try:
             self._ensure_client()
-            response = self.client.chat.completions.create(
-                model=settings.deepseek_model,
-                messages=[
-                    {"role": "system", "content": system_prompt},
-                    {"role": "user", "content": user_prompt},
-                ],
-                temperature=1,
-                stream=False
-            )
-            return response.choices[0].message.content
+            if self.provider == "deepseek":
+                response = self.client.chat.completions.create(
+                    model=settings.deepseek_model,
+                    messages=[
+                        {"role": "system", "content": system_prompt},
+                        {"role": "user", "content": user_prompt},
+                    ],
+                    temperature=1,
+                    stream=False,
+                )
+                return response.choices[0].message.content
+            elif self.provider == "ollama":
+                response = self.client.chat(
+                    model=settings.ollama_model,
+                    messages=[
+                        {"role": "system", "content": system_prompt},
+                        {"role": "user", "content": user_prompt},
+                    ],
+                )
+                return response["message"]["content"]
         except Exception as e:
-            logger.error(f"DeepSeek API error: {e}")
+            logger.error(f"{self.provider.capitalize()} API error: {e}")
             return "Ошибка анализа"

--- a/tests/test_ai_service.py
+++ b/tests/test_ai_service.py
@@ -1,75 +1,76 @@
 import pytest
 from unittest.mock import Mock, patch
 
+from config import settings
 from services.ai_service import AIService
-from utils.helpers import APIError
 
 
 class TestAIService:
-    """Тесты для сервиса работы с AI API"""
-    
+    """Тесты для сервиса работы с LLM"""
+
     @pytest.fixture
-    def ai_service(self):
-        """Фикстура для создания экземпляра AIService"""
-        with patch.dict('os.environ', {'DEEPSEEK_API_KEY': 'test_key'}):
-            return AIService()
-    
+    def deepseek_service(self, monkeypatch):
+        monkeypatch.setenv('DEEPSEEK_API_KEY', 'test_key')
+        monkeypatch.setattr(settings, 'llm_provider', 'deepseek')
+        return AIService()
+
+    @pytest.fixture
+    def ollama_service(self, monkeypatch):
+        monkeypatch.delenv('DEEPSEEK_API_KEY', raising=False)
+        monkeypatch.setattr(settings, 'llm_provider', 'ollama')
+        return AIService()
+
     @patch('services.ai_service.OpenAI')
-    def test_call_deepseek_success(self, mock_openai, ai_service):
+    def test_call_model_deepseek_success(self, mock_openai, deepseek_service):
         """Тест успешного вызова DeepSeek API"""
-        # Мок успешного ответа
         mock_response = Mock()
         mock_response.choices = [Mock()]
         mock_response.choices[0].message.content = "Test response"
         mock_openai.return_value.chat.completions.create.return_value = mock_response
-        
-        result = ai_service.call_deepseek("system", "user")
+
+        result = deepseek_service.call_model("system", "user")
         assert result == "Test response"
-        
-        # Проверяем, что API был вызван с правильными параметрами
+
         mock_openai.return_value.chat.completions.create.assert_called_once()
         call_args = mock_openai.return_value.chat.completions.create.call_args
         assert call_args[1]['model'] == 'deepseek-chat'
         assert len(call_args[1]['messages']) == 2
-    
+
     @patch('services.ai_service.OpenAI')
-    def test_call_deepseek_api_error(self, mock_openai, ai_service):
+    def test_call_model_deepseek_api_error(self, mock_openai, deepseek_service):
         """Тест обработки ошибок API"""
-        # Мок ошибки API
         mock_openai.return_value.chat.completions.create.side_effect = Exception("API Error")
-        
-        result = ai_service.call_deepseek("system", "user")
+
+        result = deepseek_service.call_model("system", "user")
         assert "Ошибка анализа" in result
-    
+
     @patch('services.ai_service.OpenAI')
-    def test_call_deepseek_empty_response(self, mock_openai, ai_service):
+    def test_call_model_deepseek_empty_response(self, mock_openai, deepseek_service):
         """Тест обработки пустого ответа"""
-        # Мок пустого ответа
         mock_response = Mock()
         mock_response.choices = [Mock()]
         mock_response.choices[0].message.content = ""
         mock_openai.return_value.chat.completions.create.return_value = mock_response
-        
-        result = ai_service.call_deepseek("system", "user")
+
+        result = deepseek_service.call_model("system", "user")
         assert result == ""
-    
-    def test_init_without_api_key(self):
+
+    def test_init_without_api_key(self, monkeypatch):
         """Тест инициализации без API ключа"""
-        with patch.dict('os.environ', {}, clear=True):
-            with pytest.raises(ValueError, match="DEEPSEEK_API_KEY must be set"):
-                AIService()
-    
+        monkeypatch.delenv('DEEPSEEK_API_KEY', raising=False)
+        monkeypatch.setattr(settings, 'llm_provider', 'deepseek')
+        with pytest.raises(ValueError, match="DEEPSEEK_API_KEY must be set"):
+            AIService()
+
     @patch('services.ai_service.OpenAI')
-    def test_call_deepseek_with_retry(self, mock_openai, ai_service):
+    def test_call_model_deepseek_with_retry(self, mock_openai, deepseek_service):
         """Тест повторных попыток при ошибке"""
-        # Первый вызов - ошибка, второй - успех
         mock_openai.return_value.chat.completions.create.side_effect = [
             Exception("Temporary error"),
             Mock(choices=[Mock(message=Mock(content="Success after retry"))])
         ]
-        
-        with patch('time.sleep'):  # Мокаем sleep для ускорения тестов
-            result = ai_service.call_deepseek("system", "user")
+        with patch('time.sleep'):
+            result = deepseek_service.call_model("system", "user")
             assert "Success after retry" in result or "Ошибка анализа" in result
 
     @patch('services.ai_service.wrap_openai')
@@ -78,6 +79,15 @@ class TestAIService:
         """Проверяем, что wrap_openai вызывается при активном LangSmith"""
         mock_openai.return_value.chat.completions.create.return_value = Mock(choices=[Mock(message=Mock(content="resp"))])
         with patch.dict('os.environ', {'DEEPSEEK_API_KEY': 'test_key', 'LANGCHAIN_API_KEY': 'ls_key'}):
+            settings.llm_provider = 'deepseek'
             service = AIService()
-            service.call_deepseek("sys", "usr")
+            service.call_model("sys", "usr")
         mock_wrap.assert_called_once()
+
+    @patch('ollama.Client')
+    def test_call_model_ollama_success(self, mock_client, ollama_service):
+        """Тест вызова локальной Ollama"""
+        mock_client.return_value.chat.return_value = {'message': {'content': 'Hi'}}
+        result = ollama_service.call_model("system", "user")
+        assert result == 'Hi'
+        mock_client.return_value.chat.assert_called_once()


### PR DESCRIPTION
## Summary
- allow switching LLM provider between DeepSeek and local Ollama
- update analyzers and docs to use generic model call
- cover new provider selection with tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b91659de0832faeec9950e9ea8735