### PR TITLE
Use hedge fund agent confidences for portfolio certainty

### DIFF
--- a/analyzers/hedge_fund_agents.py
+++ b/analyzers/hedge_fund_agents.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from typing import Dict, List
 
 from services.ai_service import AIService
-from utils.helpers import extract_recommendation
+from utils.helpers import extract_recommendation, extract_confidence
 
 logger = logging.getLogger(__name__)
 
@@ -53,50 +53,36 @@ class HedgeFundAgents:
         ),
         ]
 
-    def analyze(self, ticker: str, summary: str) -> Dict[str, str]:
-        """Возвращает рекомендации каждого агента."""
+    def analyze(self, ticker: str, summary: str) -> tuple[Dict[str, str], Dict[str, float]]:
+        """Возвращает рекомендации и уверенности каждого агента."""
         votes: Dict[str, str] = {}
+        confidences: Dict[str, float] = {}
         for agent in self.agents:
             try:
-                # system_prompt = (
-                #     f"Ты {agent.name}, {agent.description}. "
-                #     "Ответь в формате: КУПИТЬ/ДЕРЖАТЬ/ПРОДАТЬ и короткое обоснование."
-                # )
-
                 system_prompt = (
-                f"Ты выступаешь как {agent.name} — {agent.description}."
-                f"Но ты НЕ можешь ссылаться на свою репутацию или прошлые кейсы; решение принимается ТОЛЬКО по предоставленным данным и весам источников."
-
-                f"В начале ответа выведи РОВНО ОДНО слово (большими буквами):"
-                f"КУПИТЬ / ДЕРЖАТЬ / ПРОДАВАТЬ"
-
-                f"Далее выдай:"
-                f"Уверенность: X/100"
-                f"Доводы (до 3 пунктов):"
-                f"- [TAG] кратко по сути, строго из данных"
-                f"Красные флаги (до 2):"
-                f"- [TAG] кратко"
-                f"Горизонт: кратко (например, 3–6 мес)"
-
-                f"Общие правила:"
-                f"1) Учитывай веса источников: [IFRS, NEWS, MOEX, SOCIAL]."
-                f"2) При конфликте данных приоритизируй по весам. При равенстве — ДЕРЖАТЬ."
-                f"3) Не выдумывай фактов. Если чего-то не хватает — понижай уверенность."
-
+                    f"Ты выступаешь как {agent.name} — {agent.description}."
+                    f"Но ты НЕ можешь ссылаться на свою репутацию или прошлые кейсы; решение принимается ТОЛЬКО по предоставленным данным и весам источников."
+                    f"В начале ответа выведи РОВНО ОДНО слово (большими буквами):"
+                    f"КУПИТЬ / ДЕРЖАТЬ / ПРОДАВАТЬ"
+                    f"Далее выдай:"
+                    f"Уверенность: X/100"
+                    f"Доводы (до 3 пунктов):"
+                    f"- [TAG] кратко по сути, строго из данных"
+                    f"Красные флаги (до 2):"
+                    f"- [TAG] кратко"
+                    f"Горизонт: кратко (например, 3–6 мес)"
+                    f"Общие правила:"
+                    f"1) Учитывай веса источников: [IFRS, NEWS, MOEX, SOCIAL]."
+                    f"2) При конфликте данных приоритизируй по весам. При равенстве — ДЕРЖАТЬ."
+                    f"3) Не выдумывай фактов. Если чего-то не хватает — понижай уверенность."
                 )
 
-
-
-
                 user_prompt = f"Анализ по {ticker}:\n{summary}"
-
-
-
-
-
                 response = self.ai_service.call_model(system_prompt, user_prompt)
                 votes[agent.name] = extract_recommendation(response)
+                confidences[agent.name] = extract_confidence(response)
             except Exception as e:
                 logger.error(f"Agent {agent.name} failed: {e}")
                 votes[agent.name] = "ДЕРЖАТЬ"
-        return votes
+                confidences[agent.name] = 0.0
+        return votes, confidences

--- a/analyzers/portfolio_analyzer.py
+++ b/analyzers/portfolio_analyzer.py
@@ -194,12 +194,16 @@ class PortfolioAnalyzer:
                     f"Финансы: {ifrs_data}"
                 )
                 agents = HedgeFundAgents(self.ai_service)
-                votes = agents.analyze(state["ticker"], summary)
+                votes, confidences = agents.analyze(state["ticker"], summary)
             except Exception as e:
                 logger.error(f"Hedge fund agents failed {state['ticker']}: {e}")
-                votes = {}
+                votes, confidences = {}, {}
 
-            return {"final_data": analysis, "agent_votes": votes}
+            return {
+                "final_data": analysis,
+                "agent_votes": votes,
+                "agent_confidences": confidences,
+            }
 
         except (APIError, Exception) as e:
             logger.error(f"Final analysis error {state['ticker']}: {e}")
@@ -265,16 +269,22 @@ class PortfolioAnalyzer:
                 
                 # Извлекаем рекомендацию из финального анализа более надёжным способом
                 votes = result.get("agent_votes", {})
+                confidences = result.get("agent_confidences", {})
                 if votes:
                     decisions = list(votes.values())
                     recommendation = max(set(decisions), key=decisions.count)
                 else:
                     recommendation = extract_recommendation(result["final_data"])
 
+                if confidences:
+                    confidence = sum(confidences.values()) / len(confidences)
+                else:
+                    confidence = 0.0
+
                 analysis_result = AnalysisResult(
                     ticker=position.ticker,
                     recommendation=recommendation,
-                    confidence=0.8,  # базовый уровень уверенности
+                    confidence=confidence,
                     analysis_data={
                         "market_news": result["market_news"],
                         "semantic": result["semantic"],
@@ -282,6 +292,7 @@ class PortfolioAnalyzer:
                         "ifrs_data": result["ifrs_data"],
                         "final_decision": result["final_data"],
                         "agent_votes": votes,
+                        "agent_confidences": confidences,
                     }
                 )
 

--- a/models/state.py
+++ b/models/state.py
@@ -4,7 +4,8 @@ from typing import Dict, List, Optional, Any
 from dataclasses import dataclass
 from enum import Enum
 
-class State(TypedDict):
+
+class State(TypedDict, total=False):
     ticker: str
     quantity: int
     news: str
@@ -15,6 +16,8 @@ class State(TypedDict):
     final_data: str
     market_news: str
     risk_profile: str
+    agent_votes: Dict[str, str]
+    agent_confidences: Dict[str, float]
 
 class PortfolioPosition(BaseModel):
     ticker: str

--- a/tests/test_portfolio_analyzer_confidence.py
+++ b/tests/test_portfolio_analyzer_confidence.py
@@ -1,0 +1,45 @@
+import pytest
+from analyzers import PortfolioAnalyzer
+from models import Portfolio, PortfolioPosition
+
+
+def test_confidence_from_agents(monkeypatch):
+    analyzer = PortfolioAnalyzer()
+
+    def fake_generate_market_news(self, state):
+        return {"market_news": ""}
+
+    def fake_generate_news(self, state):
+        return {"news": []}
+
+    def fake_grade_news(self, state):
+        return {"semantic": ""}
+
+    def fake_moex_news(self, state):
+        return {"moex_data": ""}
+
+    def fake_make_trade_analysis(self, state):
+        return {"moex_data_analysis": ""}
+
+    def fake_ifrs_analysis(self, state):
+        return {"ifrs_data": ""}
+
+    def fake_final_analysis(self, state):
+        return {
+            "final_data": "Рекомендация: КУПИТЬ",
+            "agent_votes": {"A": "КУПИТЬ", "B": "КУПИТЬ"},
+            "agent_confidences": {"A": 0.6, "B": 0.8},
+        }
+
+    monkeypatch.setattr(PortfolioAnalyzer, "generate_market_news", fake_generate_market_news)
+    monkeypatch.setattr(PortfolioAnalyzer, "generate_news", fake_generate_news)
+    monkeypatch.setattr(PortfolioAnalyzer, "grade_news", fake_grade_news)
+    monkeypatch.setattr(PortfolioAnalyzer, "moex_news", fake_moex_news)
+    monkeypatch.setattr(PortfolioAnalyzer, "make_trade_analysis", fake_make_trade_analysis)
+    monkeypatch.setattr(PortfolioAnalyzer, "ifrs_analysis", fake_ifrs_analysis)
+    monkeypatch.setattr(PortfolioAnalyzer, "final_analysis", fake_final_analysis)
+    monkeypatch.setattr(analyzer.moex_service, "get_returns", lambda ticker: [0.1])
+
+    portfolio = Portfolio(positions=[PortfolioPosition(ticker="AAA", quantity=1)])
+    results = analyzer.analyze_portfolio(portfolio)
+    assert results["AAA"].confidence == pytest.approx(0.7)

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -69,3 +69,12 @@ def extract_recommendation(text: str) -> str:
     if "КУПИТЬ" in text:
         return "КУПИТЬ"
     return "ДЕРЖАТЬ"
+
+
+def extract_confidence(text: str) -> float:
+    """Извлекает числовое значение уверенности (0-1) из текста ответа."""
+    match = re.search(r"Уверенность[:\uFF1A]?\s*(\d{1,3})\s*/\s*100", text)
+    if match:
+        value = int(match.group(1))
+        return max(0.0, min(1.0, value / 100))
+    return 0.0


### PR DESCRIPTION
## Summary
- parse confidence levels from hedge fund agent responses
- include agent confidences in final analysis and compute average per ticker
- add coverage for confidence aggregation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4683988f4832f9ed3f6a304249d81