### PR TITLE
Align rebalancing suggestions with final decision

### DIFF
--- a/analyzers/async_portfolio_analyzer.py
+++ b/analyzers/async_portfolio_analyzer.py
@@ -46,11 +46,8 @@ class AsyncPortfolioAnalyzer(PortfolioAnalyzer):
             result = await asyncio.to_thread(chain.invoke, initial_state)
 
             votes = result.get("agent_votes", {})
-            if votes:
-                decisions = list(votes.values())
-                recommendation = max(set(decisions), key=decisions.count)
-            else:
-                recommendation = extract_recommendation(result["final_data"])
+            # Рекомендация должна основываться на финальном тексте анализа
+            recommendation = extract_recommendation(result["final_data"])
 
             analysis_result = AnalysisResult(
                 ticker=position.ticker,

--- a/analyzers/portfolio_analyzer.py
+++ b/analyzers/portfolio_analyzer.py
@@ -270,11 +270,8 @@ class PortfolioAnalyzer:
                 # Извлекаем рекомендацию из финального анализа более надёжным способом
                 votes = result.get("agent_votes", {})
                 confidences = result.get("agent_confidences", {})
-                if votes:
-                    decisions = list(votes.values())
-                    recommendation = max(set(decisions), key=decisions.count)
-                else:
-                    recommendation = extract_recommendation(result["final_data"])
+                # Рекомендация должна соответствовать финальному решению
+                recommendation = extract_recommendation(result["final_data"])
 
                 if confidences:
                     confidence = sum(confidences.values()) / len(confidences)

--- a/tests/test_recommendation_alignment.py
+++ b/tests/test_recommendation_alignment.py
@@ -1,0 +1,50 @@
+import pytest
+from analyzers import PortfolioAnalyzer, RebalancingAnalyzer
+from models import Portfolio
+
+
+def test_final_decision_aligns_with_rebalancing(monkeypatch):
+    analyzer = PortfolioAnalyzer()
+
+    def fake_generate_market_news(self, state):
+        return {"market_news": ""}
+
+    def fake_generate_news(self, state):
+        return {"news": []}
+
+    def fake_grade_news(self, state):
+        return {"semantic": ""}
+
+    def fake_moex_news(self, state):
+        return {"moex_data": ""}
+
+    def fake_make_trade_analysis(self, state):
+        return {"moex_data_analysis": ""}
+
+    def fake_ifrs_analysis(self, state):
+        return {"ifrs_data": ""}
+
+    def fake_final_analysis(self, state):
+        return {
+            "final_data": "Рекомендация: КУПИТЬ",
+            "agent_votes": {"A": "ДЕРЖАТЬ", "B": "ДЕРЖАТЬ"},
+            "agent_confidences": {},
+        }
+
+    monkeypatch.setattr(PortfolioAnalyzer, "generate_market_news", fake_generate_market_news)
+    monkeypatch.setattr(PortfolioAnalyzer, "generate_news", fake_generate_news)
+    monkeypatch.setattr(PortfolioAnalyzer, "grade_news", fake_grade_news)
+    monkeypatch.setattr(PortfolioAnalyzer, "moex_news", fake_moex_news)
+    monkeypatch.setattr(PortfolioAnalyzer, "make_trade_analysis", fake_make_trade_analysis)
+    monkeypatch.setattr(PortfolioAnalyzer, "ifrs_analysis", fake_ifrs_analysis)
+    monkeypatch.setattr(PortfolioAnalyzer, "final_analysis", fake_final_analysis)
+    monkeypatch.setattr(analyzer.moex_service, "get_returns", lambda ticker: [0.1])
+
+    portfolio = Portfolio.from_dict({"AAA": 0, "RUB": 1000})
+    results = analyzer.analyze_portfolio(portfolio)
+    assert results["AAA"].recommendation == "КУПИТЬ"
+
+    rebalancer = RebalancingAnalyzer(price_getter=lambda t: 100)
+    suggestions = rebalancer.suggest_rebalancing(results, portfolio)
+    assert suggestions["AAA"].startswith("Купить")
+


### PR DESCRIPTION
## Summary
- Derive ticker recommendations from the final analysis text to keep decisions and rebalancing suggestions in sync
- Apply the same fix to asynchronous portfolio analysis
- Add regression test ensuring rebalancing buys when final decision says to buy

## Testing
- `pytest`

------
