### PR TITLE
Fix async analyzer confidence averaging

### DIFF
--- a/analyzers/async_portfolio_analyzer.py
+++ b/analyzers/async_portfolio_analyzer.py
@@ -46,13 +46,20 @@ class AsyncPortfolioAnalyzer(PortfolioAnalyzer):
             result = await asyncio.to_thread(chain.invoke, initial_state)
 
             votes = result.get("agent_votes", {})
+            confidences = result.get("agent_confidences", {})
+
             # Рекомендация должна основываться на финальном тексте анализа
             recommendation = extract_recommendation(result["final_data"])
+            confidence = (
+                sum(confidences.values()) / len(confidences)
+                if confidences
+                else 0.0
+            )
 
             analysis_result = AnalysisResult(
                 ticker=position.ticker,
                 recommendation=recommendation,
-                confidence=0.8,
+                confidence=confidence,
                 analysis_data={
                     "market_news": result.get("market_news", ""),
                     "semantic": result.get("semantic", ""),
@@ -60,6 +67,7 @@ class AsyncPortfolioAnalyzer(PortfolioAnalyzer):
                     "ifrs_data": result.get("ifrs_data", ""),
                     "final_decision": result.get("final_data", ""),
                     "agent_votes": votes,
+                    "agent_confidences": confidences,
                 },
             )
             try:

--- a/tests/test_async_analyzer_confidence.py
+++ b/tests/test_async_analyzer_confidence.py
@@ -1,0 +1,46 @@
+import pytest
+from analyzers import AsyncPortfolioAnalyzer
+from models import Portfolio, PortfolioPosition
+
+
+@pytest.mark.asyncio
+async def test_async_confidence_from_agents(monkeypatch):
+    analyzer = AsyncPortfolioAnalyzer()
+
+    def fake_generate_market_news(self, state):
+        return {"market_news": ""}
+
+    def fake_generate_news(self, state):
+        return {"news": []}
+
+    def fake_grade_news(self, state):
+        return {"semantic": ""}
+
+    def fake_moex_news(self, state):
+        return {"moex_data": ""}
+
+    def fake_make_trade_analysis(self, state):
+        return {"moex_data_analysis": ""}
+
+    def fake_ifrs_analysis(self, state):
+        return {"ifrs_data": ""}
+
+    def fake_final_analysis(self, state):
+        return {
+            "final_data": "Рекомендация: КУПИТЬ",
+            "agent_votes": {"A": "КУПИТЬ", "B": "КУПИТЬ"},
+            "agent_confidences": {"A": 0.6, "B": 0.8},
+        }
+
+    monkeypatch.setattr(AsyncPortfolioAnalyzer, "generate_market_news", fake_generate_market_news)
+    monkeypatch.setattr(AsyncPortfolioAnalyzer, "generate_news", fake_generate_news)
+    monkeypatch.setattr(AsyncPortfolioAnalyzer, "grade_news", fake_grade_news)
+    monkeypatch.setattr(AsyncPortfolioAnalyzer, "moex_news", fake_moex_news)
+    monkeypatch.setattr(AsyncPortfolioAnalyzer, "make_trade_analysis", fake_make_trade_analysis)
+    monkeypatch.setattr(AsyncPortfolioAnalyzer, "ifrs_analysis", fake_ifrs_analysis)
+    monkeypatch.setattr(AsyncPortfolioAnalyzer, "final_analysis", fake_final_analysis)
+    monkeypatch.setattr(analyzer.moex_service, "get_returns", lambda ticker: [0.1])
+
+    portfolio = Portfolio(positions=[PortfolioPosition(ticker="AAA", quantity=1)])
+    results = await analyzer.analyze_portfolio_async(portfolio)
+    assert results["AAA"].confidence == pytest.approx(0.7)


### PR DESCRIPTION
## Summary
- compute confidence in AsyncPortfolioAnalyzer from agent confidences instead of constant 0.8
- add async analyzer confidence test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4c507f53c832fa3aa4a649993333e