### PR TITLE
feat: integrate dividend calendar into MOEX analysis

### DIFF
--- a/analyzers/portfolio_analyzer.py
+++ b/analyzers/portfolio_analyzer.py
@@ -102,7 +102,11 @@ class PortfolioAnalyzer:
             if state['moex_data'] == "Ошибка получения данных MOEX":
                 return {"moex_data_analysis": "Невозможно провести технический анализ"}
             
-            system_prompt = "Теханализ. Формат: Тренд, Объемы, Волатильность"
+            system_prompt = (
+                "Теханализ. Формат: Тренд, Объемы, Волатильность."
+                " Учитывай колонку IS_DIVIDEND_DAY: резкие падения в эти даты"
+                " могут быть связаны с дивидендной отсечкой"
+            )
             
             # Используем сервис для получения последних 180 дней
             recent_data = self.moex_service.get_recent_data(state['ticker'], 180)

--- a/services/moex_service.py
+++ b/services/moex_service.py
@@ -1,18 +1,41 @@
 import logging
-import requests
-import pandas as pd
-import apimoex
 from datetime import datetime, timedelta
-from typing import Optional
 from functools import lru_cache
-from utils.helpers import retry_on_failure, APIError
+from pathlib import Path
+from typing import Optional
+
+import apimoex
+import pandas as pd
+import requests
+
+from utils.helpers import APIError, retry_on_failure
 from config import settings
 
 logger = logging.getLogger(__name__)
 
 class MOEXService:
     """Сервис для работы с данными MOEX"""
-    
+
+    @lru_cache(maxsize=1)
+    def _load_dividend_calendar(self) -> pd.DataFrame:
+        """Загружает календарь дивидендных отсечек."""
+        path = Path(__file__).resolve().parent.parent / "finance" / "dividend.txt"
+        try:
+            df = pd.read_csv(
+                path,
+                sep=r"\s+",
+                engine="python",
+                encoding="utf-8",
+                names=["dDate", "sTicker"],
+                header=0,
+            )
+            df["dDate"] = pd.to_datetime(df["dDate"], format="%d.%m.%Y", errors="coerce")
+            df["sTicker"] = df["sTicker"].str.strip().str.upper()
+            return df
+        except Exception as e:
+            logger.error(f"Failed to load dividend calendar: {e}")
+            return pd.DataFrame(columns=["dDate", "sTicker"])
+
     @lru_cache(maxsize=128)
     @retry_on_failure(max_retries=settings.max_retries)
     def get_ticker_data(self, ticker: str, days_back: Optional[int] = None) -> pd.DataFrame:
@@ -45,6 +68,16 @@ class MOEXService:
                     raise ValueError(f"No data available for ticker {ticker}")
                 
                 df = pd.DataFrame(data)[['TRADEDATE', 'CLOSE', 'VOLUME', 'VALUE']]
+                df['TRADEDATE'] = pd.to_datetime(df['TRADEDATE'])
+
+                # Помечаем даты дивидендных отсечек
+                calendar = self._load_dividend_calendar()
+                divs = calendar[calendar['sTicker'] == ticker.upper()][['dDate']]
+                divs = divs.rename(columns={'dDate': 'TRADEDATE'})
+                divs['IS_DIVIDEND_DAY'] = True
+                df = df.merge(divs, on='TRADEDATE', how='left')
+                df['IS_DIVIDEND_DAY'] = df['IS_DIVIDEND_DAY'].fillna(False)
+
                 return df
                 
         except Exception as e:

--- a/tests/test_dividend_calendar.py
+++ b/tests/test_dividend_calendar.py
@@ -1,0 +1,25 @@
+import pandas as pd
+import apimoex
+import pytest
+
+from services import MOEXService
+
+
+def test_get_ticker_data_marks_dividend_days(monkeypatch):
+    service = MOEXService()
+
+    sample = [
+        {"TRADEDATE": "2025-01-07", "CLOSE": 100, "VOLUME": 10, "VALUE": 1000},
+        {"TRADEDATE": "2025-01-09", "CLOSE": 95, "VOLUME": 12, "VALUE": 1140},
+    ]
+
+    def fake_get_board_history(session, ticker, start, end):
+        return sample
+
+    monkeypatch.setattr(apimoex, "get_board_history", fake_get_board_history)
+
+    df = service.get_ticker_data("TATN", days_back=5)
+
+    assert df.loc[df["TRADEDATE"] == pd.Timestamp("2025-01-07"), "IS_DIVIDEND_DAY"].iloc[0]
+    assert not df.loc[df["TRADEDATE"] == pd.Timestamp("2025-01-09"), "IS_DIVIDEND_DAY"].iloc[0]
+


### PR DESCRIPTION
## Summary
- load dividend ex-date calendar and flag MOEX data rows with IS_DIVIDEND_DAY
- adjust technical analysis to consider dividend-related price drops
- add test covering dividend flag integration

## Testing
- `pytest`


------
