### PR TITLE
feat: persist recommendations and add backtesting

### DIFF
--- a/backtest.py
+++ b/backtest.py
@@ -1,0 +1,10 @@
+from services import BacktestService
+
+if __name__ == "__main__":
+    service = BacktestService()
+    stats = service.run_backtest()
+    print(
+        f"Всего рекомендаций: {stats['total']}, "
+        f"Корректных: {stats['correct']}, "
+        f"Средняя доходность: {stats['avg_return']:.2%}"
+    )

--- a/main.py
+++ b/main.py
@@ -3,7 +3,11 @@ import asyncio
 import json
 import argparse
 
-from models import Portfolio, RiskProfile
+from models import (
+    Portfolio,
+    RiskProfile,
+    RecommendationRecord,
+)
 from analyzers import PortfolioAnalyzer, RebalancingAnalyzer, AsyncPortfolioAnalyzer
 from utils import (
     log_performance_summary,
@@ -11,6 +15,7 @@ from utils import (
     get_performance_report,
     performance_monitor,
 )
+from services import RecommendationDB, MOEXService
 from datetime import datetime
 import os
 
@@ -204,6 +209,24 @@ def print_analysis_results(results: dict):
         print(f"{ticker:<6} {action}")
 
 
+def save_recommendations_to_db(results: dict) -> None:
+    """Сохраняет рекомендации в локальную БД."""
+    db = RecommendationDB()
+    moex = MOEXService()
+    now = datetime.now()
+    for ticker, data in results.get("analysis_results", {}).items():
+        price = moex.get_latest_price(ticker)
+        record = RecommendationRecord(
+            ticker=ticker,
+            recommendation=data["recommendation"],
+            confidence=data["confidence"],
+            price=price,
+            timestamp=now,
+        )
+        db.save(record)
+    db.close()
+
+
 def generate_analysis_report(results: dict) -> str:
     """Формирует текстовый отчет по результатам анализа."""
     if "error" in results:
@@ -391,7 +414,10 @@ if __name__ == "__main__":
             "rebalancing_suggestions": {},
             "portfolio_summary": {"error": "Ошибка анализа"},
         }
-    
+
+    # Сохраняем рекомендации
+    save_recommendations_to_db(results)
+
     # Выводим результаты
     print_analysis_results(results)
 

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -5,6 +5,7 @@ from .state import (
     AnalysisResult,
     RiskProfile,
 )
+from .recommendation import RecommendationRecord
 
 __all__ = [
     'State',
@@ -12,4 +13,5 @@ __all__ = [
     'PortfolioPosition',
     'AnalysisResult',
     'RiskProfile',
+    'RecommendationRecord',
 ]

--- a/models/recommendation.py
+++ b/models/recommendation.py
@@ -1,0 +1,22 @@
+from datetime import datetime
+from pydantic import BaseModel, validator
+
+class RecommendationRecord(BaseModel):
+    """Модель записи рекомендации для хранения в БД."""
+    ticker: str
+    recommendation: str
+    confidence: float
+    price: float
+    timestamp: datetime
+
+    @validator("ticker")
+    def validate_ticker(cls, v: str) -> str:
+        if not v or len(v) < 2:
+            raise ValueError("Ticker must be at least 2 characters")
+        return v.upper()
+
+    @validator("confidence")
+    def validate_confidence(cls, v: float) -> float:
+        if not 0.0 <= v <= 1.0:
+            raise ValueError("Confidence must be between 0 and 1")
+        return v

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -2,5 +2,14 @@ from .ai_service import AIService
 from .news_service import NewsService
 from .moex_service import MOEXService
 from .ifrs_service import IFRSService
+from .db_service import RecommendationDB
+from .backtest_service import BacktestService
 
-__all__ = ['AIService', 'NewsService', 'MOEXService', 'IFRSService']
+__all__ = [
+    'AIService',
+    'NewsService',
+    'MOEXService',
+    'IFRSService',
+    'RecommendationDB',
+    'BacktestService',
+]

--- a/services/backtest_service.py
+++ b/services/backtest_service.py
@@ -1,0 +1,60 @@
+from datetime import timedelta
+from typing import Dict
+
+import pandas as pd
+
+from .db_service import RecommendationDB
+from .moex_service import MOEXService
+
+
+class BacktestService:
+    """Сервис для оценки качества рекомендаций."""
+
+    def __init__(self, db_path: str = "recommendations.db") -> None:
+        self.db = RecommendationDB(db_path)
+        self.moex_service = MOEXService()
+
+    def run_backtest(self, holding_period: int = 5) -> Dict[str, float]:
+        """Проводит бэктест рекомендаций.
+
+        Args:
+            holding_period: количество дней удержания позиции
+
+        Returns:
+            Словарь с метриками бэктеста
+        """
+        records = self.db.fetch_all()
+        if not records:
+            return {"total": 0, "correct": 0, "avg_return": 0.0}
+
+        total_return = 0.0
+        correct = 0
+
+        for rec in records:
+            try:
+                df: pd.DataFrame = self.moex_service.get_ticker_data(
+                    rec.ticker, days_back=holding_period + 10
+                )
+                df = df.sort_values("TRADEDATE")
+                target_date = rec.timestamp.date() + timedelta(days=holding_period)
+                future = df[df["TRADEDATE"] >= pd.Timestamp(target_date)]
+                if future.empty:
+                    continue
+                future_price = float(future.iloc[0]["CLOSE"])
+                ret = (future_price - rec.price) / rec.price
+                total_return += ret
+
+                if rec.recommendation == "КУПИТЬ" and ret > 0:
+                    correct += 1
+                elif rec.recommendation == "ПРОДАВАТЬ" and ret < 0:
+                    correct += 1
+                elif rec.recommendation == "ДЕРЖАТЬ" and abs(ret) < 0.01:
+                    correct += 1
+            except Exception:
+                continue
+
+        return {
+            "total": len(records),
+            "correct": correct,
+            "avg_return": total_return / len(records),
+        }

--- a/services/db_service.py
+++ b/services/db_service.py
@@ -1,0 +1,93 @@
+import sqlite3
+from pathlib import Path
+from typing import List, Optional
+from datetime import datetime
+
+from models import RecommendationRecord
+
+
+class RecommendationDB:
+    """Простой сервис для сохранения рекомендаций в SQLite."""
+
+    def __init__(self, db_path: str = "recommendations.db") -> None:
+        self.db_path = Path(db_path)
+        self.conn = sqlite3.connect(str(self.db_path))
+        self._create_table()
+
+    def _create_table(self) -> None:
+        cursor = self.conn.cursor()
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS recommendations (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                ticker TEXT NOT NULL,
+                recommendation TEXT NOT NULL,
+                confidence REAL NOT NULL,
+                price REAL NOT NULL,
+                timestamp TEXT NOT NULL
+            )
+            """
+        )
+        self.conn.commit()
+
+    def save(self, record: RecommendationRecord) -> None:
+        cursor = self.conn.cursor()
+        cursor.execute(
+            """
+            INSERT INTO recommendations (ticker, recommendation, confidence, price, timestamp)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (
+                record.ticker,
+                record.recommendation,
+                record.confidence,
+                record.price,
+                record.timestamp.isoformat(),
+            ),
+        )
+        self.conn.commit()
+
+    def fetch_all(self) -> List[RecommendationRecord]:
+        cursor = self.conn.cursor()
+        cursor.execute(
+            "SELECT ticker, recommendation, confidence, price, timestamp FROM recommendations"
+        )
+        rows = cursor.fetchall()
+        records = [
+            RecommendationRecord(
+                ticker=row[0],
+                recommendation=row[1],
+                confidence=row[2],
+                price=row[3],
+                timestamp=datetime.fromisoformat(row[4]),
+            )
+            for row in rows
+        ]
+        return records
+
+    def fetch_latest(self, ticker: str) -> Optional[RecommendationRecord]:
+        """Возвращает последнюю рекомендацию для указанного тикера."""
+        cursor = self.conn.cursor()
+        cursor.execute(
+            """
+            SELECT ticker, recommendation, confidence, price, timestamp
+            FROM recommendations
+            WHERE ticker = ?
+            ORDER BY timestamp DESC
+            LIMIT 1
+            """,
+            (ticker.upper(),),
+        )
+        row = cursor.fetchone()
+        if not row:
+            return None
+        return RecommendationRecord(
+            ticker=row[0],
+            recommendation=row[1],
+            confidence=row[2],
+            price=row[3],
+            timestamp=datetime.fromisoformat(row[4]),
+        )
+
+    def close(self) -> None:
+        self.conn.close()

--- a/show_recommendations.py
+++ b/show_recommendations.py
@@ -1,0 +1,38 @@
+import argparse
+from services import RecommendationDB
+
+
+def format_record(rec):
+    return (
+        f"{rec.timestamp:%Y-%m-%d %H:%M} {rec.ticker} "
+        f"{rec.recommendation} ({rec.confidence:.2f}) @ {rec.price:.2f}"
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Показывает сохранённые рекомендации из локальной БД"
+    )
+    parser.add_argument(
+        "-t",
+        "--ticker",
+        help="Показать только последнюю рекомендацию для тикера",
+    )
+    args = parser.parse_args()
+    db = RecommendationDB()
+    try:
+        if args.ticker:
+            rec = db.fetch_latest(args.ticker)
+            if rec:
+                print(format_record(rec))
+            else:
+                print(f"Рекомендаций для {args.ticker} не найдено")
+        else:
+            for rec in db.fetch_all():
+                print(format_record(rec))
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_backtest_service.py
+++ b/tests/test_backtest_service.py
@@ -1,0 +1,39 @@
+from datetime import datetime
+
+import pandas as pd
+
+from models import RecommendationRecord
+from services.db_service import RecommendationDB
+from services.backtest_service import BacktestService
+
+
+def test_backtest_simple(tmp_path, mocker):
+    db_path = tmp_path / "rec.db"
+    db = RecommendationDB(db_path)
+    rec = RecommendationRecord(
+        ticker="SBER",
+        recommendation="КУПИТЬ",
+        confidence=0.8,
+        price=100.0,
+        timestamp=datetime(2024, 1, 1),
+    )
+    db.save(rec)
+    db.close()
+
+    df = pd.DataFrame(
+        {
+            "TRADEDATE": [pd.Timestamp("2024-01-01"), pd.Timestamp("2024-01-06")],
+            "CLOSE": [100.0, 110.0],
+            "VOLUME": [0, 0],
+            "VALUE": [0, 0],
+        }
+    )
+    mocker.patch(
+        "services.backtest_service.MOEXService.get_ticker_data", return_value=df
+    )
+
+    service = BacktestService(db_path)
+    stats = service.run_backtest(holding_period=5)
+    assert stats["total"] == 1
+    assert stats["correct"] == 1
+    assert abs(stats["avg_return"] - 0.1) < 1e-6

--- a/tests/test_db_service.py
+++ b/tests/test_db_service.py
@@ -1,0 +1,50 @@
+from datetime import datetime
+
+from services.db_service import RecommendationDB
+from models import RecommendationRecord
+
+
+def test_save_and_fetch(tmp_path):
+    db_path = tmp_path / "rec.db"
+    db = RecommendationDB(db_path)
+    record = RecommendationRecord(
+        ticker="SBER",
+        recommendation="КУПИТЬ",
+        confidence=0.9,
+        price=100.0,
+        timestamp=datetime(2024, 1, 1),
+    )
+    db.save(record)
+    records = db.fetch_all()
+    db.close()
+
+    assert len(records) == 1
+    assert records[0].ticker == "SBER"
+    assert records[0].recommendation == "КУПИТЬ"
+
+
+def test_fetch_latest(tmp_path):
+    db_path = tmp_path / "rec.db"
+    db = RecommendationDB(db_path)
+    first = RecommendationRecord(
+        ticker="SBER",
+        recommendation="КУПИТЬ",
+        confidence=0.8,
+        price=90.0,
+        timestamp=datetime(2024, 1, 1, 10, 0, 0),
+    )
+    second = RecommendationRecord(
+        ticker="SBER",
+        recommendation="ПРОДАВАТЬ",
+        confidence=0.6,
+        price=110.0,
+        timestamp=datetime(2024, 1, 2, 10, 0, 0),
+    )
+    db.save(first)
+    db.save(second)
+    latest = db.fetch_latest("sber")
+    db.close()
+
+    assert latest is not None
+    assert latest.recommendation == "ПРОДАВАТЬ"
+    assert latest.timestamp == datetime(2024, 1, 2, 10, 0, 0)


### PR DESCRIPTION
## Summary
- allow retrieving the most recent recommendation for a ticker from the local database
- add CLI helper to display stored recommendations
- cover latest recommendation lookup with tests

## Testing
- `python -m pip install -r req.txt`
- `pytest`


