### PR TITLE
Handle missing MOEX data gracefully

### DIFF
--- a/main.py
+++ b/main.py
@@ -14,6 +14,7 @@ from utils import (
     calculate_portfolio_value,
     get_performance_report,
     performance_monitor,
+    APIError,
 )
 from services import RecommendationDB, MOEXService
 from datetime import datetime
@@ -215,7 +216,11 @@ def save_recommendations_to_db(results: dict) -> None:
     moex = MOEXService()
     now = datetime.now()
     for ticker, data in results.get("analysis_results", {}).items():
-        price = moex.get_latest_price(ticker)
+        try:
+            price = moex.get_latest_price(ticker)
+        except APIError as e:
+            logger.error(f"Skipping {ticker}: {e}")
+            continue
         record = RecommendationRecord(
             ticker=ticker,
             recommendation=data["recommendation"],

--- a/services/moex_service.py
+++ b/services/moex_service.py
@@ -76,7 +76,12 @@ class MOEXService:
                 divs = divs.rename(columns={'dDate': 'TRADEDATE'})
                 divs['IS_DIVIDEND_DAY'] = True
                 df = df.merge(divs, on='TRADEDATE', how='left')
-                df['IS_DIVIDEND_DAY'] = df['IS_DIVIDEND_DAY'].fillna(False)
+                df['IS_DIVIDEND_DAY'] = (
+                    df['IS_DIVIDEND_DAY']
+                    .astype('boolean')
+                    .fillna(False)
+                    .astype(bool)
+                )
 
                 return df
                 


### PR DESCRIPTION
## Summary
- avoid pandas downcast warning by coercing dividend flag to boolean
- skip saving recommendations when MOEX price data is unavailable

## Testing
- `pytest -q`
