### PR TITLE
feat: make async analyzer concurrency configurable

### DIFF
--- a/analyzers/async_portfolio_analyzer.py
+++ b/analyzers/async_portfolio_analyzer.py
@@ -2,6 +2,8 @@ import asyncio
 import logging
 from typing import Dict, Tuple
 
+from config import settings
+
 from langgraph.graph import StateGraph, START, END
 from langsmith import traceable
 
@@ -21,8 +23,10 @@ logger = logging.getLogger(__name__)
 class AsyncPortfolioAnalyzer(PortfolioAnalyzer):
     """Асинхронная версия PortfolioAnalyzer с параллельной обработкой тикеров."""
 
-    def __init__(self, max_concurrent_tasks: int = 5):
+    def __init__(self, max_concurrent_tasks: int | None = None):
         super().__init__()
+        if max_concurrent_tasks is None:
+            max_concurrent_tasks = settings.max_concurrent_tasks
         self.semaphore = asyncio.Semaphore(max_concurrent_tasks)
 
     async def _analyze_single(

--- a/config.py
+++ b/config.py
@@ -22,10 +22,11 @@ class Settings(BaseSettings):
     moex_days_lookback: int = 180
     max_news_items: int = 3
     max_ifrs_content_length: int = 1500
-    
+
     # Лимиты API
     api_timeout: int = 30
     max_retries: int = 3
+    max_concurrent_tasks: int = 20
     
 
 settings = Settings()


### PR DESCRIPTION
## Summary
- allow configuring concurrent analysis tasks through `max_concurrent_tasks` setting (default 20)
- use config value in `AsyncPortfolioAnalyzer` when limit not provided

## Testing
- `pytest tests/test_async_analyzer.py tests/test_async_analyzer_confidence.py`

------
https://chatgpt.com/codex/tasks/task_e_68aac23b9890832fbcd886d4e7d7e4d9