### PR TITLE
Raise APIError and handle retries

### DIFF
--- a/analyzers/hedge_fund_agents.py
+++ b/analyzers/hedge_fund_agents.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from typing import Dict, List
 
 from services.ai_service import AIService
-from utils.helpers import extract_recommendation, extract_confidence
+from utils.helpers import APIError, extract_recommendation, extract_confidence
 
 logger = logging.getLogger(__name__)
 
@@ -82,6 +82,10 @@ class HedgeFundAgents:
                 response = self.ai_service.call_model(system_prompt, user_prompt)
                 votes[agent.name] = extract_recommendation(response)
                 confidences[agent.name] = extract_confidence(response)
+            except APIError as e:
+                logger.error(f"Agent {agent.name} API error: {e}")
+                votes[agent.name] = "ДЕРЖАТЬ"
+                confidences[agent.name] = 0.0
             except Exception as e:
                 logger.error(f"Agent {agent.name} failed: {e}")
                 votes[agent.name] = "ДЕРЖАТЬ"

--- a/analyzers/portfolio_analyzer.py
+++ b/analyzers/portfolio_analyzer.py
@@ -44,17 +44,20 @@ class PortfolioAnalyzer:
         """Получение и анализ новостей с lenta.ru"""
         try:
             news_entries = self.news_service.get_market_news()
-            
+
             if news_entries:
                 system_prompt = "Анализ новостей рынка. Формат: Настрой, Факторы, Влияние"
                 user_prompt = f"Новости:\n{news_entries}"
-                
+
                 analysis = self.ai_service.call_model(system_prompt, user_prompt)
                 return {"market_news": analysis}
-            
+
             return {"market_news": "Недостаточно свежих новостей для анализа"}
-            
-        except (APIError, Exception) as e:
+
+        except APIError as e:
+            logger.error(f"Market news API error: {e}")
+            return {"market_news": "Ошибка при анализе новостей"}
+        except Exception as e:
             logger.error(f"Market news error: {e}")
             return {"market_news": "Ошибка при анализе новостей"}
 
@@ -64,7 +67,10 @@ class PortfolioAnalyzer:
         try:
             texts = self.news_service.get_ticker_news(state['ticker'])
             return {"news": texts}
-        except (APIError, Exception) as e:
+        except APIError as e:
+            logger.error(f"News API error {state['ticker']}: {e}")
+            return {"news": []}
+        except Exception as e:
             logger.error(f"News error {state['ticker']}: {e}")
             return {"news": []}
 
@@ -74,14 +80,17 @@ class PortfolioAnalyzer:
         try:
             if not state['news']:
                 return {"semantic": "Нет новостей для анализа"}
-            
+
             system_prompt = "Анализ новостей компании. Формат: Настрой, Ключевое, Риски"
             user_prompt = f"Новости {state['ticker']}:\n{state['news']}"
-            
+
             analysis = self.ai_service.call_model(system_prompt, user_prompt)
             return {"semantic": analysis}
-            
-        except (APIError, Exception) as e:
+
+        except APIError as e:
+            logger.error(f"Grade API error {state['ticker']}: {e}")
+            return {"semantic": "Ошибка анализа новостей"}
+        except Exception as e:
             logger.error(f"Grade error {state['ticker']}: {e}")
             return {"semantic": "Ошибка анализа новостей"}
 
@@ -91,7 +100,10 @@ class PortfolioAnalyzer:
         try:
             df = self.moex_service.get_ticker_data(state['ticker'])
             return {"moex_data": df.to_string(index=False)}
-        except (APIError, Exception) as e:
+        except APIError as e:
+            logger.error(f"MOEX API error {state['ticker']}: {e}")
+            return {"moex_data": "Ошибка получения данных MOEX"}
+        except Exception as e:
             logger.error(f"MOEX error {state['ticker']}: {e}")
             return {"moex_data": "Ошибка получения данных MOEX"}
 
@@ -101,21 +113,24 @@ class PortfolioAnalyzer:
         try:
             if state['moex_data'] == "Ошибка получения данных MOEX":
                 return {"moex_data_analysis": "Невозможно провести технический анализ"}
-            
+
             system_prompt = (
                 "Теханализ. Формат: Тренд, Объемы, Волатильность."
                 " Учитывай колонку IS_DIVIDEND_DAY: резкие падения в эти даты"
                 " могут быть связаны с дивидендной отсечкой"
             )
-            
+
             # Используем сервис для получения последних 180 дней
             recent_data = self.moex_service.get_recent_data(state['ticker'], 180)
             user_prompt = f"Данные {state['ticker']}:\n{recent_data}"
-            
+
             analysis = self.ai_service.call_model(system_prompt, user_prompt)
             return {"moex_data_analysis": analysis}
-            
-        except (APIError, Exception) as e:
+
+        except APIError as e:
+            logger.error(f"Trade analysis API error {state['ticker']}: {e}")
+            return {"moex_data_analysis": "Ошибка технического анализа"}
+        except Exception as e:
             logger.error(f"Trade analysis error {state['ticker']}: {e}")
             return {"moex_data_analysis": "Ошибка технического анализа"}
 
@@ -124,17 +139,23 @@ class PortfolioAnalyzer:
         """Анализ IFRS отчетности"""
         try:
             ifrs_content = self.ifrs_service.get_ifrs_data(state['ticker'])
-            
+
             if "не найдена" in ifrs_content:
                 return {"ifrs_data": ifrs_content}
-            
+
             system_prompt = "Анализ МСФО. Формат: Финансы, Рентабельность, Долги"
             user_prompt = f"Отчетность {state['ticker']}:\n{ifrs_content}"
-            
+
             analysis = self.ai_service.call_model(system_prompt, user_prompt)
             return {"ifrs_data": analysis}
-            
-        except (APIError, DataProcessingError, Exception) as e:
+
+        except APIError as e:
+            logger.error(f"IFRS API error {state['ticker']}: {e}")
+            return {"ifrs_data": "Ошибка анализа МСФО"}
+        except DataProcessingError as e:
+            logger.error(f"IFRS data error {state['ticker']}: {e}")
+            return {"ifrs_data": "Ошибка анализа МСФО"}
+        except Exception as e:
             logger.error(f"IFRS error {state['ticker']}: {e}")
             return {"ifrs_data": "Ошибка анализа МСФО"}
 
@@ -209,7 +230,10 @@ class PortfolioAnalyzer:
                 "agent_confidences": confidences,
             }
 
-        except (APIError, Exception) as e:
+        except APIError as e:
+            logger.error(f"Final analysis API error {state['ticker']}: {e}")
+            return {"final_data": "Ошибка финального анализа"}
+        except Exception as e:
             logger.error(f"Final analysis error {state['ticker']}: {e}")
             return {"final_data": "Ошибка финального анализа"}
 

--- a/services/ai_service.py
+++ b/services/ai_service.py
@@ -44,8 +44,8 @@ class AIService:
     @retry_on_failure(max_retries=settings.max_retries)
     def call_model(self, system_prompt: str, user_prompt: str) -> str:
         """Унифицированный вызов LLM"""
+        self._ensure_client()
         try:
-            self._ensure_client()
             if self.provider == "deepseek":
                 response = self.client.chat.completions.create(
                     model=settings.deepseek_model,
@@ -66,6 +66,8 @@ class AIService:
                     ],
                 )
                 return response["message"]["content"]
+            else:
+                raise ValueError(f"Unsupported provider: {self.provider}")
         except Exception as e:
             logger.error(f"{self.provider.capitalize()} API error: {e}")
-            return "Ошибка анализа"
+            raise APIError(f"{self.provider.capitalize()} API error: {e}") from e

--- a/tests/test_ai_service.py
+++ b/tests/test_ai_service.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock, patch
 
 from config import settings
 from services.ai_service import AIService
+from utils.helpers import APIError
 
 
 class TestAIService:
@@ -41,8 +42,13 @@ class TestAIService:
         """Тест обработки ошибок API"""
         mock_openai.return_value.chat.completions.create.side_effect = Exception("API Error")
 
-        result = deepseek_service.call_model("system", "user")
-        assert "Ошибка анализа" in result
+        with patch('time.sleep'):
+            with pytest.raises(APIError):
+                deepseek_service.call_model("system", "user")
+        assert (
+            mock_openai.return_value.chat.completions.create.call_count
+            == settings.max_retries
+        )
 
     @patch('services.ai_service.OpenAI')
     def test_call_model_deepseek_empty_response(self, mock_openai, deepseek_service):
@@ -71,7 +77,8 @@ class TestAIService:
         ]
         with patch('time.sleep'):
             result = deepseek_service.call_model("system", "user")
-            assert "Success after retry" in result or "Ошибка анализа" in result
+        assert result == "Success after retry"
+        assert mock_openai.return_value.chat.completions.create.call_count == 2
 
     @patch('services.ai_service.wrap_openai')
     @patch('services.ai_service.OpenAI')

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -24,11 +24,13 @@ def retry_on_failure(max_retries: int = 3, delay: float = 1.0):
             for attempt in range(max_retries):
                 try:
                     return func(*args, **kwargs)
-                except (requests.RequestException, ConnectionError) as e:
+                except (requests.RequestException, ConnectionError, APIError) as e:
                     if attempt == max_retries - 1:
                         logger.error(f"Failed after {max_retries} attempts: {e}")
-                        raise APIError(f"API call failed after {max_retries} attempts: {e}")
-                    logger.warning(f"Attempt {attempt + 1} failed: {e}. Retrying in {delay}s...")
+                        raise APIError(f"API call failed after {max_retries} attempts: {e}") from e
+                    logger.warning(
+                        f"Attempt {attempt + 1} failed: {e}. Retrying in {delay}s..."
+                    )
                     time.sleep(delay)
                 except Exception as e:
                     logger.error(f"Unexpected error in {func.__name__}: {e}")


### PR DESCRIPTION
## Summary
- Raise `APIError` from `AIService.call_model` instead of returning error strings
- Extend `retry_on_failure` to retry on `APIError`
- Handle `APIError` in HedgeFundAgents and PortfolioAnalyzer call sites
- Update tests for new error-handling behavior

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'feedparser')*

------
https://chatgpt.com/codex/tasks/task_e_68aee71202b8832f904ed17113c3d555