### PR TITLE
Handle missing price column in MOEX service

### DIFF
--- a/services/__init__.py
+++ b/services/__init__.py
@@ -1,15 +1,30 @@
-from .ai_service import AIService
-from .news_service import NewsService
-from .moex_service import MOEXService
-from .ifrs_service import IFRSService
-from .db_service import RecommendationDB
-from .backtest_service import BacktestService
-
 __all__ = [
-    'AIService',
-    'NewsService',
-    'MOEXService',
-    'IFRSService',
-    'RecommendationDB',
-    'BacktestService',
+    "AIService",
+    "NewsService",
+    "MOEXService",
+    "IFRSService",
+    "RecommendationDB",
+    "BacktestService",
 ]
+
+
+def __getattr__(name):
+    if name == "AIService":
+        from .ai_service import AIService
+        return AIService
+    if name == "NewsService":
+        from .news_service import NewsService
+        return NewsService
+    if name == "MOEXService":
+        from .moex_service import MOEXService
+        return MOEXService
+    if name == "IFRSService":
+        from .ifrs_service import IFRSService
+        return IFRSService
+    if name == "RecommendationDB":
+        from .db_service import RecommendationDB
+        return RecommendationDB
+    if name == "BacktestService":
+        from .backtest_service import BacktestService
+        return BacktestService
+    raise AttributeError(f"module {__name__} has no attribute {name}")

--- a/services/moex_service.py
+++ b/services/moex_service.py
@@ -133,10 +133,25 @@ class MOEXService:
             sec = data.get("securities", {})
             if not sec:
                 raise ValueError("No data returned")
+
             df = pd.DataFrame(sec["data"], columns=sec["columns"])
-            df = df[["SECID", "PREVCLOSE"]].rename(
-                columns={"SECID": "ticker", "PREVCLOSE": "price"}
-            )
+
+            price_columns = [
+                "PREVCLOSE",
+                "PREVPRICE",
+                "PREVADMITTEDQUOTE",
+                "CLOSEPRICE",
+                "LAST",
+            ]
+            for col in price_columns:
+                if col in df.columns:
+                    df = df[["SECID", col]].rename(
+                        columns={"SECID": "ticker", col: "price"}
+                    )
+                    break
+            else:
+                raise KeyError("No known price column found")
+
             df["ticker"] = df["ticker"].str.upper()
             return df.set_index("ticker")
         except Exception as e:

--- a/tests/test_moex_service_latest_prices.py
+++ b/tests/test_moex_service_latest_prices.py
@@ -1,0 +1,39 @@
+from services.moex_service import MOEXService
+
+
+class DummyResponse:
+    def __init__(self, json_data):
+        self._json = json_data
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return self._json
+
+
+class DummySession:
+    def __init__(self, json_data):
+        self._json = json_data
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+    def get(self, url, params=None):
+        return DummyResponse(self._json)
+
+
+def test_get_latest_prices_uses_available_columns(monkeypatch):
+    json_data = {
+        "securities": {
+            "columns": ["SECID", "PREVADMITTEDQUOTE"],
+            "data": [["TRNFP", 123.45]],
+        }
+    }
+    monkeypatch.setattr("requests.Session", lambda: DummySession(json_data))
+    service = MOEXService()
+    df = service.get_latest_prices(["TRNFP"])
+    assert df.loc["TRNFP", "price"] == 123.45


### PR DESCRIPTION
## Summary
- handle multiple possible column names when fetching latest prices from MOEX
- lazily import service modules to avoid heavy dependencies during tests
- add regression test for MOEX price fallback

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'openai'; ModuleNotFoundError: No module named 'langsmith')*
- `pytest tests/test_moex_service_latest_prices.py -q`

