### PR TITLE
feat: add OpenAI ChatGPT provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Анализ портфеля акций
 
-Этот проект представляет собой инструмент для анализа портфеля акций, использующий данные из различных источников (Tinkoff Pulse, MOEX, новостные ленты, отчетность МСФО) и искусственный интеллект (DeepSeek API или локальный Ollama) для формирования инвестиционных рекомендаций.
+Этот проект представляет собой инструмент для анализа портфеля акций, использующий данные из различных источников (Tinkoff Pulse, MOEX, новостные ленты, отчетность МСФО) и искусственный интеллект (DeepSeek API, OpenAI ChatGPT API или локальный Ollama) для формирования инвестиционных рекомендаций.
 
 ## Основные возможности
 - Сбор новостей по тикерам из Tinkoff Pulse
@@ -51,11 +51,15 @@ pip install -r requirements.txt
 
 Создайте файл `.env` и укажите необходимые ключи и настройки:
 ```env
-LLM_PROVIDER=deepseek                 # или 'ollama'
+LLM_PROVIDER=deepseek                 # или 'ollama' или 'openai'
 
 # DeepSeek
 DEEPSEEK_API_KEY=your_actual_key
 DEEPSEEK_MODEL=deepseek-reasoner или deepseek-chat
+
+# OpenAI
+OPENAI_API_KEY=your_openai_key
+OPENAI_MODEL=gpt-4o-mini
 
 # Локальная Ollama
 OLLAMA_MODEL=llama3:8b

--- a/SETUP.md
+++ b/SETUP.md
@@ -13,7 +13,7 @@ portfolio_analyzer/
 │   └── state.py           # Portfolio, AnalysisResult
 ├── services/              # Сервисный слой
 │   ├── __init__.py
-│   ├── ai_service.py      # LLM API (DeepSeek/Ollama)
+│   ├── ai_service.py      # LLM API (DeepSeek/OpenAI/Ollama)
 │   ├── news_service.py    # Новости (Lenta.ru, Tinkoff Pulse)
 │   ├── moex_service.py    # Данные MOEX
 │   └── ifrs_service.py    # IFRS отчетность
@@ -57,12 +57,17 @@ cp .env.example .env
 Отредактируйте `.env`:
 ```env
 # LLM provider configuration
-LLM_PROVIDER=deepseek              # или 'ollama'
+LLM_PROVIDER=deepseek              # или 'ollama' или 'openai'
 
 # DeepSeek API Configuration
 DEEPSEEK_API_KEY=your_actual_api_key_here
 DEEPSEEK_MODEL=deepseek-chat
 DEEPSEEK_BASE_URL=https://api.deepseek.com
+
+# OpenAI API Configuration
+OPENAI_API_KEY=your_openai_key
+OPENAI_MODEL=gpt-4o-mini
+# OPENAI_BASE_URL=https://api.openai.com/v1
 
 # Local Ollama configuration
 OLLAMA_MODEL=llama3:8b

--- a/config.py
+++ b/config.py
@@ -14,6 +14,9 @@ class Settings(BaseSettings):
     deepseek_api_key: str | None = os.getenv("DEEPSEEK_API_KEY")
     deepseek_model: str = "deepseek-chat"
     deepseek_base_url: str = "https://api.deepseek.com"
+    openai_api_key: str | None = os.getenv("OPENAI_API_KEY")
+    openai_model: str = os.getenv("OPENAI_MODEL", "gpt-4o-mini")
+    openai_base_url: str | None = os.getenv("OPENAI_BASE_URL")
     ollama_model: str = os.getenv("OLLAMA_MODEL", "llama3:8b")
     ollama_base_url: str = os.getenv("OLLAMA_BASE_URL", "http://localhost:11434")
     

--- a/services/ai_service.py
+++ b/services/ai_service.py
@@ -12,15 +12,23 @@ from utils.monitoring import monitor_performance
 logger = logging.getLogger(__name__)
 
 class AIService:
-    """Сервис для работы с LLM провайдерами (DeepSeek или локальная Ollama)"""
+    """Сервис для работы с LLM провайдерами (DeepSeek, OpenAI или локальная Ollama)"""
 
     def __init__(self, api_key: Optional[str] = None):
         self.provider = settings.llm_provider.lower()
+        if self.provider == "chatgpt":
+            self.provider = "openai"
+
         if self.provider == "deepseek":
             env_key = os.getenv("DEEPSEEK_API_KEY")
             self.api_key = api_key or env_key
             if not self.api_key:
                 raise ValueError("DEEPSEEK_API_KEY must be set")
+        elif self.provider == "openai":
+            env_key = os.getenv("OPENAI_API_KEY")
+            self.api_key = api_key or env_key
+            if not self.api_key:
+                raise ValueError("OPENAI_API_KEY must be set")
         else:
             self.api_key = None
         self.client: Optional[Any] = None
@@ -32,6 +40,14 @@ class AIService:
                     api_key=self.api_key,
                     base_url=settings.deepseek_base_url,
                 )
+                if os.getenv("LANGCHAIN_API_KEY") or os.getenv("LANGSMITH_API_KEY"):
+                    client = wrap_openai(client)
+                self.client = client
+            elif self.provider == "openai":
+                kwargs = {"api_key": self.api_key}
+                if settings.openai_base_url:
+                    kwargs["base_url"] = settings.openai_base_url
+                client = OpenAI(**kwargs)
                 if os.getenv("LANGCHAIN_API_KEY") or os.getenv("LANGSMITH_API_KEY"):
                     client = wrap_openai(client)
                 self.client = client
@@ -49,6 +65,17 @@ class AIService:
             if self.provider == "deepseek":
                 response = self.client.chat.completions.create(
                     model=settings.deepseek_model,
+                    messages=[
+                        {"role": "system", "content": system_prompt},
+                        {"role": "user", "content": user_prompt},
+                    ],
+                    temperature=1,
+                    stream=False,
+                )
+                return response.choices[0].message.content
+            elif self.provider == "openai":
+                response = self.client.chat.completions.create(
+                    model=settings.openai_model,
                     messages=[
                         {"role": "system", "content": system_prompt},
                         {"role": "user", "content": user_prompt},

--- a/tests/test_ai_service.py
+++ b/tests/test_ai_service.py
@@ -21,6 +21,13 @@ class TestAIService:
         monkeypatch.setattr(settings, 'llm_provider', 'ollama')
         return AIService()
 
+    @pytest.fixture
+    def openai_service(self, monkeypatch):
+        monkeypatch.delenv('DEEPSEEK_API_KEY', raising=False)
+        monkeypatch.setenv('OPENAI_API_KEY', 'test_key')
+        monkeypatch.setattr(settings, 'llm_provider', 'openai')
+        return AIService()
+
     @patch('services.ai_service.OpenAI')
     def test_call_model_deepseek_success(self, mock_openai, deepseek_service):
         """Тест успешного вызова DeepSeek API"""
@@ -98,3 +105,37 @@ class TestAIService:
         result = ollama_service.call_model("system", "user")
         assert result == 'Hi'
         mock_client.return_value.chat.assert_called_once()
+
+    @patch('services.ai_service.OpenAI')
+    def test_call_model_openai_success(self, mock_openai, openai_service):
+        """Тест успешного вызова OpenAI API"""
+        mock_response = Mock()
+        mock_response.choices = [Mock()]
+        mock_response.choices[0].message.content = "OpenAI response"
+        mock_openai.return_value.chat.completions.create.return_value = mock_response
+
+        result = openai_service.call_model("system", "user")
+        assert result == "OpenAI response"
+
+        mock_openai.return_value.chat.completions.create.assert_called_once()
+        call_args = mock_openai.return_value.chat.completions.create.call_args
+        assert call_args[1]['model'] == 'gpt-4o-mini'
+
+    @patch('services.ai_service.OpenAI')
+    def test_call_model_openai_api_error(self, mock_openai, openai_service):
+        """Тест обработки ошибок OpenAI API"""
+        mock_openai.return_value.chat.completions.create.side_effect = Exception("API Error")
+
+        with patch('time.sleep'):
+            with pytest.raises(APIError):
+                openai_service.call_model("system", "user")
+        assert (
+            mock_openai.return_value.chat.completions.create.call_count
+            == settings.max_retries
+        )
+
+    def test_openai_init_without_api_key(self, monkeypatch):
+        monkeypatch.delenv('OPENAI_API_KEY', raising=False)
+        monkeypatch.setattr(settings, 'llm_provider', 'openai')
+        with pytest.raises(ValueError, match="OPENAI_API_KEY must be set"):
+            AIService()


### PR DESCRIPTION
## Summary
- support OpenAI ChatGPT in AI service alongside DeepSeek and Ollama
- document OpenAI configuration in README and setup guide
- cover OpenAI provider with dedicated tests

## Testing
- `pytest`
