### PR TITLE
Handle duplicate tickers in MOEX price data

### DIFF
--- a/services/moex_service.py
+++ b/services/moex_service.py
@@ -153,6 +153,8 @@ class MOEXService:
                 raise KeyError("No known price column found")
 
             df["ticker"] = df["ticker"].str.upper()
+            # Ensure unique tickers to avoid reindex errors downstream
+            df = df.drop_duplicates(subset="ticker", keep="first")
             return df.set_index("ticker")
         except Exception as e:
             logger.error(f"Failed to get prices for {tickers}: {e}")
@@ -162,7 +164,8 @@ class MOEXService:
         """Возвращает ряд доходностей по закрытиям."""
         try:
             df = self.get_ticker_data(ticker, days_back=days_back)
-            returns = df['CLOSE'].pct_change().dropna().tolist()
+            # Explicitly disable filling to avoid future pandas warnings
+            returns = df['CLOSE'].pct_change(fill_method=None).dropna().tolist()
             return [float(r) for r in returns]
         except Exception as e:
             logger.error(f"Failed to get returns for {ticker}: {e}")


### PR DESCRIPTION
## Summary
- Ensure MOEX price fetcher drops duplicate tickers to avoid reindex errors
- Silence pandas pct_change deprecation warning in return calculation

## Testing
- `pip install pydantic-settings`
- `pytest` *(fails: ModuleNotFoundError: No module named 'openai')*

------
https://chatgpt.com/codex/tasks/task_e_68af671453d0832f8e1b70084c8b79b7