### PR TITLE
Display buy intent when cash is insufficient

### DIFF
--- a/analyzers/rebalancing_analyzer.py
+++ b/analyzers/rebalancing_analyzer.py
@@ -98,7 +98,7 @@ class RebalancingAnalyzer:
         missing_buy_prices = set(buy_tickers) - set(buy_df.index)
         excluded_tickers.update(missing_buy_prices)
 
-        if not buy_df.empty and cash > 0:
+        if not buy_df.empty:
             adjusted_prices = buy_df["price"] * (1 + self.BROKER_FEE)
             base_quantities = (cash / len(buy_df) / adjusted_prices).astype(int)
             spent = (base_quantities * adjusted_prices).sum()
@@ -115,7 +115,7 @@ class RebalancingAnalyzer:
             quantities = (base_quantities + additional).astype(int)
             cash = cash_remaining
 
-            for ticker, qty in quantities[quantities > 0].items():
+            for ticker, qty in quantities.items():
                 rebalancing_suggestions[ticker] = f"Купить {int(qty)}"
 
         for ticker, result in analysis_results.items():

--- a/tests/test_recommendation_alignment.py
+++ b/tests/test_recommendation_alignment.py
@@ -39,3 +39,18 @@ def test_final_decision_aligns_with_rebalancing():
 
     assert suggestions["AAA"].startswith("Купить")
 
+
+def test_buy_recommendation_with_no_cash_shows_zero_quantity():
+    portfolio = Portfolio.from_dict({"AAA": 0, "RUB": 0})
+    results = {
+        "AAA": AnalysisResult(
+            ticker="AAA", recommendation="КУПИТЬ", confidence=1.0, analysis_data={}
+        )
+    }
+
+    price_df = pd.DataFrame({"price": [100.0]}, index=["AAA"])
+    rebalancer = RebalancingAnalyzer(price_getter=lambda ts: price_df.loc[ts])
+    suggestions = rebalancer.suggest_rebalancing(results, portfolio)
+
+    assert suggestions["AAA"] == "Купить 0"
+


### PR DESCRIPTION
## Summary
- ensure rebalancing analyzer records buy recommendations even with zero cash
- add regression test for zero-cash buy recommendations

## Testing
- `pytest tests/test_recommendation_alignment.py::test_buy_recommendation_with_no_cash_shows_zero_quantity -q`
- `pytest -q`


