### PR TITLE
Replace LangSmith integration with Langfuse

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,9 @@ OPENAI_MODEL=gpt-4o-mini
 OLLAMA_MODEL=llama3:8b
 OLLAMA_BASE_URL=http://localhost:11434
 
-# Опционально: включение трасировки LangSmith
-LANGCHAIN_API_KEY=your_langsmith_key
+# Опционально: включение трасировки Langfuse
+LANGFUSE_PUBLIC_KEY=your_langfuse_public_key
+LANGFUSE_SECRET_KEY=your_langfuse_secret_key
 ```
 Дополнительные переменные могут быть заданы по желанию. Неизвестные
 переменные будут просто игнорироваться при загрузке настроек.

--- a/analyzers/async_portfolio_analyzer.py
+++ b/analyzers/async_portfolio_analyzer.py
@@ -5,7 +5,6 @@ from typing import Dict, Tuple
 from config import settings
 
 from langgraph.graph import StateGraph, START, END
-from langsmith import traceable
 
 from models.state import (
     State,

--- a/analyzers/portfolio_analyzer.py
+++ b/analyzers/portfolio_analyzer.py
@@ -1,7 +1,7 @@
 import logging
 import os
 from typing import Dict, Optional
-from langsmith import traceable
+from langfuse import observe
 from langgraph.graph import StateGraph, START, END
 from io import StringIO
 import pandas as pd
@@ -50,7 +50,7 @@ class PortfolioAnalyzer:
         self.weights = {k: v["weight"] for k, v in self.modules_config.items()}
         self._market_news_cache: Optional[str] = None
     
-    @traceable
+    @observe()
     def generate_market_news(self, state: State) -> dict:
         """Получение и анализ новостей с lenta.ru"""
         if not self.modules_config.get("market_news", {}).get("enabled", True):
@@ -83,7 +83,7 @@ class PortfolioAnalyzer:
             self._market_news_cache = msg
             return {"market_news": msg}
 
-    @traceable
+    @observe()
     def generate_news(self, state: State) -> dict:
         """Получение новостей по тикеру"""
         if not self.modules_config.get("social", {}).get("enabled", True):
@@ -98,7 +98,7 @@ class PortfolioAnalyzer:
             logger.error(f"News error {state['ticker']}: {e}")
             return {"news": []}
 
-    @traceable
+    @observe()
     def grade_news(self, state: State) -> dict:
         """Анализ новостей компании"""
         if not self.modules_config.get("social", {}).get("enabled", True):
@@ -120,7 +120,7 @@ class PortfolioAnalyzer:
             logger.error(f"Grade error {state['ticker']}: {e}")
             return {"semantic": "Ошибка анализа новостей", "news": ""}
 
-    @traceable
+    @observe()
     def moex_news(self, state: State) -> dict:
         """Получение данных MOEX"""
         if not self.modules_config.get("moex", {}).get("enabled", True):
@@ -135,7 +135,7 @@ class PortfolioAnalyzer:
             logger.error(f"MOEX error {state['ticker']}: {e}")
             return {"moex_data": "Ошибка получения данных MOEX"}
 
-    @traceable
+    @observe()
     def make_trade_analysis(self, state: State) -> dict:
         """Технический анализ торговых данных"""
         if not self.modules_config.get("moex", {}).get("enabled", True):
@@ -167,7 +167,7 @@ class PortfolioAnalyzer:
             logger.error(f"Trade analysis error {state['ticker']}: {e}")
             return {"moex_data_analysis": "Ошибка технического анализа", "moex_data": ""}
 
-    @traceable
+    @observe()
     def ifrs_analysis(self, state: State) -> dict:
         """Анализ IFRS отчетности"""
         if not self.modules_config.get("ifrs", {}).get("enabled", True):
@@ -194,7 +194,7 @@ class PortfolioAnalyzer:
             logger.error(f"IFRS error {state['ticker']}: {e}")
             return {"ifrs_data": "Ошибка анализа МСФО"}
 
-    @traceable
+    @observe()
 
     def final_analysis(self, state: State) -> dict:
         """Финальный анализ и рекомендация"""

--- a/analyzers/rebalancing_analyzer.py
+++ b/analyzers/rebalancing_analyzer.py
@@ -2,7 +2,7 @@ import logging
 from typing import Callable, Dict, List
 
 import pandas as pd
-from langsmith import traceable
+from langfuse import observe
 
 from models.state import AnalysisResult, Portfolio, RiskProfile
 from services.moex_service import MOEXService
@@ -24,7 +24,7 @@ class RebalancingAnalyzer:
         """
         self.price_getter = price_getter or MOEXService().get_latest_prices
 
-    @traceable
+    @observe()
     def suggest_rebalancing(
         self,
         analysis_results: Dict[str, AnalysisResult],

--- a/req.txt
+++ b/req.txt
@@ -41,7 +41,7 @@ langgraph-checkpoint==2.0.23
 langgraph-cli==0.1.79
 langgraph-prebuilt==0.1.1
 langgraph-sdk==0.1.58
-langsmith==0.3.18
+langfuse==3.3.2
 marshmallow==3.26.1
 msgpack==1.1.0
 multidict==6.1.0

--- a/services/ai_service.py
+++ b/services/ai_service.py
@@ -3,7 +3,7 @@ import os
 from typing import Optional, Any
 
 from openai import OpenAI
-from langsmith.wrappers import wrap_openai
+import langfuse.openai as langfuse_openai
 
 from config import settings
 from utils.helpers import retry_on_failure, APIError
@@ -35,21 +35,20 @@ class AIService:
 
     def _ensure_client(self):
         if self.client is None:
+            if self.provider in {"deepseek", "openai"}:
+                if os.getenv("LANGFUSE_PUBLIC_KEY") and os.getenv("LANGFUSE_SECRET_KEY"):
+                    langfuse_openai.register_tracing()
             if self.provider == "deepseek":
                 client = OpenAI(
                     api_key=self.api_key,
                     base_url=settings.deepseek_base_url,
                 )
-                if os.getenv("LANGCHAIN_API_KEY") or os.getenv("LANGSMITH_API_KEY"):
-                    client = wrap_openai(client)
                 self.client = client
             elif self.provider == "openai":
                 kwargs = {"api_key": self.api_key}
                 if settings.openai_base_url:
                     kwargs["base_url"] = settings.openai_base_url
                 client = OpenAI(**kwargs)
-                if os.getenv("LANGCHAIN_API_KEY") or os.getenv("LANGSMITH_API_KEY"):
-                    client = wrap_openai(client)
                 self.client = client
             elif self.provider == "ollama":
                 from ollama import Client as OllamaClient

--- a/tests/test_ai_service.py
+++ b/tests/test_ai_service.py
@@ -87,16 +87,20 @@ class TestAIService:
         assert result == "Success after retry"
         assert mock_openai.return_value.chat.completions.create.call_count == 2
 
-    @patch('services.ai_service.wrap_openai')
+    @patch('services.ai_service.langfuse_openai.register_tracing')
     @patch('services.ai_service.OpenAI')
-    def test_wrap_openai_called_when_langsmith_enabled(self, mock_openai, mock_wrap):
-        """Проверяем, что wrap_openai вызывается при активном LangSmith"""
+    def test_register_tracing_called_when_langfuse_enabled(self, mock_openai, mock_register):
+        """Проверяем, что register_tracing вызывается при активном Langfuse"""
         mock_openai.return_value.chat.completions.create.return_value = Mock(choices=[Mock(message=Mock(content="resp"))])
-        with patch.dict('os.environ', {'DEEPSEEK_API_KEY': 'test_key', 'LANGCHAIN_API_KEY': 'ls_key'}):
+        with patch.dict('os.environ', {
+            'DEEPSEEK_API_KEY': 'test_key',
+            'LANGFUSE_PUBLIC_KEY': 'pk',
+            'LANGFUSE_SECRET_KEY': 'sk',
+        }):
             settings.llm_provider = 'deepseek'
             service = AIService()
             service.call_model("sys", "usr")
-        mock_wrap.assert_called_once()
+        mock_register.assert_called_once()
 
     @patch('ollama.Client')
     def test_call_model_ollama_success(self, mock_client, ollama_service):


### PR DESCRIPTION
## Summary
- instrument OpenAI calls with Langfuse instead of LangSmith
- switch analyzers to Langfuse's `observe` decorator
- document Langfuse environment variables and dependency

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic_settings')*
