### PR TITLE
feat: support local langfuse

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ OLLAMA_BASE_URL=http://localhost:11434
 # Опционально: включение трасировки Langfuse
 LANGFUSE_PUBLIC_KEY=your_langfuse_public_key
 LANGFUSE_SECRET_KEY=your_langfuse_secret_key
+LANGFUSE_HOST=http://localhost:3030
 ```
 Дополнительные переменные могут быть заданы по желанию. Неизвестные
 переменные будут просто игнорироваться при загрузке настроек.

--- a/config.py
+++ b/config.py
@@ -23,6 +23,9 @@ class Settings(BaseSettings):
     openai_base_url: str | None = os.getenv("OPENAI_BASE_URL")
     ollama_model: str = os.getenv("OLLAMA_MODEL", "llama3:8b")
     ollama_base_url: str = os.getenv("OLLAMA_BASE_URL", "http://localhost:11434")
+
+    # Langfuse configuration
+    langfuse_host: str = os.getenv("LANGFUSE_HOST", "http://localhost:3030")
     
     # Параметры анализа
     news_days_lookback: int = 1

--- a/services/ai_service.py
+++ b/services/ai_service.py
@@ -37,6 +37,7 @@ class AIService:
         if self.client is None:
             if self.provider in {"deepseek", "openai"}:
                 if os.getenv("LANGFUSE_PUBLIC_KEY") and os.getenv("LANGFUSE_SECRET_KEY"):
+                    os.environ.setdefault("LANGFUSE_HOST", settings.langfuse_host)
                     langfuse_openai.register_tracing()
             if self.provider == "deepseek":
                 client = OpenAI(

--- a/tests/test_ai_service.py
+++ b/tests/test_ai_service.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 from unittest.mock import Mock, patch
 
@@ -100,6 +102,20 @@ class TestAIService:
             settings.llm_provider = 'deepseek'
             service = AIService()
             service.call_model("sys", "usr")
+        mock_register.assert_called_once()
+
+    @patch('services.ai_service.OpenAI')
+    @patch('services.ai_service.langfuse_openai.register_tracing')
+    def test_langfuse_host_default_set(self, mock_register, mock_openai, monkeypatch):
+        """Проверяем установку LANGFUSE_HOST по умолчанию"""
+        monkeypatch.setenv('DEEPSEEK_API_KEY', 'test_key')
+        monkeypatch.setattr(settings, 'llm_provider', 'deepseek')
+        monkeypatch.setenv('LANGFUSE_PUBLIC_KEY', 'pk')
+        monkeypatch.setenv('LANGFUSE_SECRET_KEY', 'sk')
+        monkeypatch.delenv('LANGFUSE_HOST', raising=False)
+        service = AIService()
+        service._ensure_client()
+        assert os.environ['LANGFUSE_HOST'] == settings.langfuse_host
         mock_register.assert_called_once()
 
     @patch('ollama.Client')


### PR DESCRIPTION
## Summary
- allow configuring Langfuse host for local deployments
- set LANGFUSE_HOST when tracing enabled
- document Langfuse host env var and add test

## Testing
- `pytest`
