### PR TITLE
weight buys by confidence

### DIFF
--- a/analyzers/rebalancing_analyzer.py
+++ b/analyzers/rebalancing_analyzer.py
@@ -100,14 +100,28 @@ class RebalancingAnalyzer:
 
         if not buy_df.empty:
             adjusted_prices = buy_df["price"] * (1 + self.BROKER_FEE)
-            base_quantities = (cash / len(buy_df) / adjusted_prices).astype(int)
+
+            confidences = pd.Series(
+                {t: analysis_results[t].confidence for t in buy_df.index},
+                index=buy_df.index,
+            )
+            # Распределяем базовые средства пропорционально уверенности
+            total_conf = confidences.sum()
+            if total_conf > 0:
+                weights = confidences / total_conf
+            else:
+                weights = pd.Series(1 / len(buy_df), index=buy_df.index)
+
+            base_quantities = (cash * weights / adjusted_prices).astype(int)
             spent = (base_quantities * adjusted_prices).sum()
             cash_remaining = cash - spent
 
             additional = pd.Series(0, index=buy_df.index, dtype=int)
-            for ticker, price in adjusted_prices.sort_values().items():
+            # Оставшиеся деньги направляем в тикеры с большей уверенностью
+            for ticker in confidences.sort_values(ascending=False).index:
+                price = adjusted_prices[ticker]
                 if cash_remaining < price:
-                    break
+                    continue
                 qty = int(cash_remaining / price)
                 additional[ticker] = qty
                 cash_remaining -= qty * price

--- a/tests/test_rebalancing.py
+++ b/tests/test_rebalancing.py
@@ -65,6 +65,25 @@ def test_rebalancing_zero_quantity_sell():
     assert "AAA" not in result
 
 
+def test_rebalancing_considers_confidence():
+    portfolio = Portfolio.from_dict({"AAA": 0, "BBB": 0, "RUB": 10000})
+    analysis_results = {
+        "AAA": AnalysisResult(
+            ticker="AAA", recommendation="КУПИТЬ", confidence=1.0, analysis_data={}
+        ),
+        "BBB": AnalysisResult(
+            ticker="BBB", recommendation="КУПИТЬ", confidence=0.5, analysis_data={}
+        ),
+    }
+
+    price_df = pd.DataFrame({"price": [1000.0, 1000.0]}, index=["AAA", "BBB"])
+    analyzer = RebalancingAnalyzer(price_getter=lambda ts: price_df.loc[ts])
+    result = analyzer.suggest_rebalancing(analysis_results, portfolio)
+
+    assert result["AAA"] == "Купить 6"
+    assert result["BBB"] == "Купить 3"
+
+
 def test_rebalancing_many_assets_performance():
     tickers = [f"T{i:03d}" for i in range(200)]
     portfolio_data = {t: 0 for t in tickers}


### PR DESCRIPTION
## Summary
- distribute buy orders proportionally to analysis confidence
- spend leftover cash starting from highest-confidence tickers
- cover new logic with a dedicated test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b5f8c06e84832f91446b7bb4dc9d5d