### PR TITLE
Add single stock speculation prediction CLI

### DIFF
--- a/analysis/__init__.py
+++ b/analysis/__init__.py
@@ -1,6 +1,9 @@
 from .portfolio_analysis import analyze_portfolio_improved, analyze_portfolio_async
+from .single_stock_speculation import predict_stock_direction, evaluate_prediction
 
 __all__ = [
     "analyze_portfolio_improved",
     "analyze_portfolio_async",
+    "predict_stock_direction",
+    "evaluate_prediction",
 ]

--- a/analysis/single_stock_speculation.py
+++ b/analysis/single_stock_speculation.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, time
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+from services.moex_service import MOEXService
+
+logger = logging.getLogger(__name__)
+
+# Файл для хранения сделанных прогнозов
+PREDICTIONS_FILE = Path("speculation_predictions.json")
+
+
+def _load_predictions() -> list[dict]:
+    """Загружает сохранённые прогнозы из файла."""
+    if PREDICTIONS_FILE.exists():
+        try:
+            return json.loads(PREDICTIONS_FILE.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            logger.warning("Файл прогнозов повреждён, создаём новый")
+            return []
+    return []
+
+
+def _save_predictions(predictions: list[dict]) -> None:
+    PREDICTIONS_FILE.write_text(
+        json.dumps(predictions, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+
+
+def predict_stock_direction(ticker: str) -> dict:
+    """Делает прогноз по отдельной акции: упадёт цена или нет.
+
+    Прогноз должен быть выполнен до 12:00 МСК. Используется простое
+    правило: если текущая цена закрытия выше среднего за 5 дней,
+    прогнозируется падение.
+    """
+    now = datetime.now(ZoneInfo("Europe/Moscow"))
+    if now.time() > time(12, 0):
+        raise RuntimeError("Прогноз должен быть сделан до 12:00 МСК")
+
+    moex = MOEXService()
+    df = moex.get_ticker_data(ticker)
+    last_close = float(df["CLOSE"].iloc[-1])
+    ma5 = float(df["CLOSE"].tail(5).mean())
+    prediction = "down" if last_close > ma5 else "not_down"
+
+    record = {
+        "ticker": ticker.upper(),
+        "prediction": prediction,
+        "reference_price": last_close,
+        "timestamp": now.isoformat(),
+    }
+    predictions = _load_predictions()
+    predictions.append(record)
+    _save_predictions(predictions)
+    logger.info("Сохранён прогноз для %s: %s", ticker, prediction)
+    return record
+
+
+def evaluate_prediction(ticker: str) -> dict:
+    """Оценивает ранее сделанный прогноз.
+
+    Оценка возможна только после 19:09 МСК. Сравнивает реальную цену
+    закрытия с ценой, использованной в прогнозе.
+    """
+    now = datetime.now(ZoneInfo("Europe/Moscow"))
+    if now.time() < time(19, 9):
+        raise RuntimeError("Оценку можно проводить после 19:09 МСК")
+
+    predictions = _load_predictions()
+    prediction = next(
+        (p for p in reversed(predictions) if p["ticker"] == ticker.upper()),
+        None,
+    )
+    if prediction is None:
+        raise RuntimeError("Прогноз для указанного тикера не найден")
+
+    moex = MOEXService()
+    df = moex.get_ticker_data(ticker, days_back=1)
+    actual_price = float(df["CLOSE"].iloc[-1])
+    price_fell = actual_price < prediction["reference_price"]
+    was_correct = (prediction["prediction"] == "down") == price_fell
+
+    prediction.update({
+        "actual_price": actual_price,
+        "was_correct": was_correct,
+    })
+    _save_predictions(predictions)
+    logger.info(
+        "Оценка прогноза для %s: %s", ticker, "верный" if was_correct else "неверный"
+    )
+    return {
+        "ticker": ticker.upper(),
+        "predicted": prediction["prediction"],
+        "actual_price": actual_price,
+        "was_correct": was_correct,
+    }

--- a/single_stock_cli.py
+++ b/single_stock_cli.py
@@ -1,0 +1,42 @@
+import argparse
+import logging
+
+from analysis import predict_stock_direction, evaluate_prediction
+from utils.logging_config import setup_logging
+
+setup_logging()
+logger = logging.getLogger(__name__)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Single stock speculation tool")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    predict_parser = subparsers.add_parser("predict", help="Сделать прогноз")
+    predict_parser.add_argument("ticker", help="Тикер акции")
+
+    evaluate_parser = subparsers.add_parser("evaluate", help="Оценить прогноз")
+    evaluate_parser.add_argument("ticker", help="Тикер акции")
+
+    args = parser.parse_args()
+
+    if args.command == "predict":
+        result = predict_stock_direction(args.ticker)
+        print(
+            f"Прогноз для {result['ticker']}: "
+            f"{'упадёт' if result['prediction']=='down' else 'не упадёт'}, "
+            f"цена {result['reference_price']}"
+        )
+    elif args.command == "evaluate":
+        result = evaluate_prediction(args.ticker)
+        print(
+            f"Результат для {result['ticker']}: "
+            f"{'верно' if result['was_correct'] else 'неверно'}, "
+            f"фактическая цена {result['actual_price']}"
+        )
+    else:
+        logger.error("Неизвестная команда")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_single_stock_speculation.py
+++ b/tests/test_single_stock_speculation.py
@@ -1,0 +1,62 @@
+import pandas as pd
+from datetime import datetime
+from zoneinfo import ZoneInfo
+from unittest.mock import patch
+import importlib.util
+from pathlib import Path
+import sys
+import types
+
+dummy_service = types.ModuleType("services.moex_service")
+
+
+class DummyMOEXService:
+    def get_ticker_data(self, *args, **kwargs):  # pragma: no cover - replaced in tests
+        raise NotImplementedError
+
+
+dummy_service.MOEXService = DummyMOEXService
+sys.modules["services.moex_service"] = dummy_service
+
+spec = importlib.util.spec_from_file_location(
+    "single_stock_speculation",
+    Path(__file__).resolve().parents[1] / "analysis/single_stock_speculation.py",
+)
+sss = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(sss)
+
+
+def test_predict_and_evaluate(tmp_path):
+    # Используем временный файл для прогнозов
+    sss.PREDICTIONS_FILE = tmp_path / "predictions.json"
+
+    df = pd.DataFrame(
+        {
+            "TRADEDATE": pd.date_range("2024-01-01", periods=5),
+            "CLOSE": [100, 101, 102, 103, 110],
+        }
+    )
+
+    with patch.object(sss, "MOEXService") as MockService:
+        mock_service = MockService.return_value
+        mock_service.get_ticker_data.return_value = df
+        with patch.object(sss, "datetime") as mock_dt:
+            mock_dt.now.return_value = datetime(
+                2024, 1, 10, 11, 0, tzinfo=ZoneInfo("Europe/Moscow")
+            )
+            record = sss.predict_stock_direction("SBER")
+    assert record["prediction"] == "down"
+    assert sss.PREDICTIONS_FILE.exists()
+
+    eval_df = pd.DataFrame(
+        {"TRADEDATE": [pd.Timestamp("2024-01-10")], "CLOSE": [108]}
+    )
+    with patch.object(sss, "MOEXService") as MockService:
+        mock_service = MockService.return_value
+        mock_service.get_ticker_data.return_value = eval_df
+        with patch.object(sss, "datetime") as mock_dt:
+            mock_dt.now.return_value = datetime(
+                2024, 1, 10, 19, 10, tzinfo=ZoneInfo("Europe/Moscow")
+            )
+            result = sss.evaluate_prediction("SBER")
+    assert result["was_correct"] is True


### PR DESCRIPTION
## Summary
- add speculation analysis for a single stock with prediction and evaluation
- expose prediction utilities and provide command line interface
- cover prediction workflow with tests

## Testing
- `pytest tests/test_single_stock_speculation.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b81877f088832fb03c355efd29ee3d